### PR TITLE
Add warning to bin_time

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# palaeoverse (development version)
+
+* Added warning to bin_time (#104)
+* Improved link accessibility (#88)
+
 # palaeoverse 1.2.1
 
 * Fixed handling of multiple models in palaeorotate (#92)

--- a/R/bin_time.R
+++ b/R/bin_time.R
@@ -196,6 +196,13 @@ bin_time <- function(occdf, bins, method = "mid", reps = 100,
         occdf$mid_ma <- (occdf$max_ma + occdf$min_ma) / 2
         rmcol <- TRUE
       }
+      # Check if mid_ma equivalent to any bin boundaries
+      if(any(occdf$mid_ma %in% bins$mid_ma)) {
+        warning(paste("One or more occurrences have a midpoint age",
+                      "equivalent to a bin boundary. Binning skipped for",
+                      "these occurrences.",
+                      "Hint: `which(is.na(occdf$bin_assignment))`."))
+      }
 
       # Assign bin based on midpoint age of the age range
       for (i in seq_len(nrow(bins))) {


### PR DESCRIPTION
This PR adds a warning to address #104:

> "When running bin_time(method = "mid"), occurrences with a mid_ma that fall right on the boundary of two stages get an NA for their bin assignment. Is there a reasonable way to address this? If not, should the user be alerted to the issue?"

I've opted for a warning here to let the user know what is going on. Another option would be to always bin to the younger or older interval (or both). However, I think this is undesirable and the user should take this decision for themselves. 

Closes #104.  