### PR TITLE
Add age arguments to bin_time

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# palaeoverse (development version)
+
+* Added age arguments (max_ma/min_ma) to bin_time (#106)
+
 # palaeoverse 1.2.1
 
 * Fixed handling of multiple models in palaeorotate (#92)

--- a/man/bin_time.Rd
+++ b/man/bin_time.Rd
@@ -4,7 +4,16 @@
 \alias{bin_time}
 \title{Assign fossil occurrences to time bins}
 \usage{
-bin_time(occdf, bins, method = "mid", reps = 100, fun = dunif, ...)
+bin_time(
+  occdf,
+  min_ma = "min_ma",
+  max_ma = "max_ma",
+  bins,
+  method = "mid",
+  reps = 100,
+  fun = dunif,
+  ...
+)
 }
 \arguments{
 \item{occdf}{\code{dataframe}. A dataframe of the fossil occurrences you
@@ -13,11 +22,20 @@ wish to bin. This dataframe should contain the following named columns:
 required, \code{numeric} ages can be generated from interval names via the
 \code{\link[palaeoverse:look_up]{look_up()}} function.}
 
+\item{min_ma}{\code{character}. The name of the column you wish to be
+treated as the minimum age for \code{occdf} and \code{bins}, e.g. "min_ma"
+(default).}
+
+\item{max_ma}{\code{character}. The name of the column you wish to be
+treated as the maximum age for \code{occdf} and \code{bins}, e.g. "max_ma"
+(default).}
+
 \item{bins}{\code{dataframe}. A dataframe of the bins that you wish to
 allocate fossil occurrences to such as that returned by
 \code{\link[palaeoverse:time_bins]{time_bins()}}. This dataframe must
-contain at least the following named columns: "bin", "max_ma" and
-"min_ma". Columns "max_ma" and "min_ma" must be \code{numeric} values.}
+contain at least the following named columns: "bin" and those specified
+to \code{max_ma} (default: "max_ma") and \code{min_ma} (default: "min_ma).
+Columns \code{max_ma} and \code{min_ma} must be \code{numeric} values.}
 
 \item{method}{\code{character}. The method desired for binning fossil
 occurrences. Currently, five methods exist in this function: "mid",

--- a/man/bin_time.Rd
+++ b/man/bin_time.Rd
@@ -17,9 +17,10 @@ bin_time(
 }
 \arguments{
 \item{occdf}{\code{dataframe}. A dataframe of the fossil occurrences you
-wish to bin. This dataframe should contain the following named columns:
-"max_ma" and "min_ma". These columns should contain \code{numeric} values. If
-required, \code{numeric} ages can be generated from interval names via the
+wish to bin. This dataframe should contain at least two columns with
+\code{numeric} values: maximum age of occurrence and minimum age of
+occurrence (see \code{max_ma}, \code{min_ma}). If required, \code{numeric} ages can be
+generated from interval names via the
 \code{\link[palaeoverse:look_up]{look_up()}} function.}
 
 \item{min_ma}{\code{character}. The name of the column you wish to be
@@ -34,7 +35,7 @@ treated as the maximum age for \code{occdf} and \code{bins}, e.g. "max_ma"
 allocate fossil occurrences to such as that returned by
 \code{\link[palaeoverse:time_bins]{time_bins()}}. This dataframe must
 contain at least the following named columns: "bin" and those specified
-to \code{max_ma} (default: "max_ma") and \code{min_ma} (default: "min_ma).
+to \code{max_ma} (default: "max_ma") and \code{min_ma} (default: "min_ma").
 Columns \code{max_ma} and \code{min_ma} must be \code{numeric} values.}
 
 \item{method}{\code{character}. The method desired for binning fossil


### PR DESCRIPTION
This PR adds age arguments (`max_ma` and `min_ma`) to the `bin_time` function. This allows users to easily specify different column names for their age data. Rather than having many new additional arguments, I have updated the function so that these `max_ma` and `min_ma` also relate to `bins`. Currently, users will still need to have a "bin" column in `bins`. Do we also want to add an argument for that to allow modification? 

As one of the original developers and reviewers, would you be willing to review @ChristopherDavidDean and @willgearty?

Closes #106.