### PR TITLE
Remove superfluous columns #110

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
 * Added age arguments (max_ma/min_ma) to bin_time (#106)
 * Added warning to bin_time (#104)
 * Improved link accessibility (#88)
+* Fix superfluous columns in palaeorotate (#110)
 
 
 # palaeoverse 1.2.1

--- a/R/palaeorotate.R
+++ b/R/palaeorotate.R
@@ -593,6 +593,9 @@ palaeorotate <- function(occdf, lng = "lng", lat = "lat", age = "age",
   # Add warning
   if (length(model) == 1) {
     cnames <- c("p_lng", "p_lat")
+    if (method == "point") {
+      occdf <- occdf[, -which(colnames(occdf) %in% paste0(cnames, "_", model))]
+    }
   }
   if (any(is.na(occdf[, unlist(cnames)]))) {
     warning(


### PR DESCRIPTION
This PR removes the superfluous columns generated when using `method = "point"` in `palaeorotate` which occurs when only one global plate model is defined e.g. `model = "PALEOMAP"` (see #110 for details).

Fixes #110.
