### PR TITLE
Fix point bug in tax_range_strat

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# palaeoverse 1.3.1
+
+* Fixed point plotting bug in tax_range_strat
+
 # palaeoverse 1.3.0
 
 * Added plot customisability to tax_range_time (#99)

--- a/R/tax_range_strat.R
+++ b/R/tax_range_strat.R
@@ -237,12 +237,12 @@ tax_range_strat <- function(occdf, name = "genus", level = "bed",
              col = cols[1], lty = ltys[1], lwd = lwds[1])
   }
   if (is.null(certainty)) {
-    points(y = occdf$bed, x = occdf$ID, pch = pchs[1],
+    points(y = occdf[, level], x = occdf$ID, pch = pchs[1],
            col = cols[1], bg = bgs[1], cex = cexs[1])
   } else {
-    points(y = certain$bed, x = certain$ID, pch = pchs[1],
+    points(y = certain[, level], x = certain$ID, pch = pchs[1],
            col = cols[1], bg = bgs[1], cex = cexs[1])
-    points(y = uncertain$bed, x = uncertain$ID, pch = pchs[2],
+    points(y = uncertain[, level], x = uncertain$ID, pch = pchs[2],
            col = cols[2], bg = bgs[2], cex = cexs[2])
   }
   # plot y-axis


### PR DESCRIPTION
This branch fixes a bug in tax_range_strat().
At present, the code for plotting the points references a column named `bed`, and if an alternative name is used (e.g. `height`) then the column is not identified. This fix instead pulls the column name based on the input `level`.