### PR TITLE
tax_range_time/strat grouping

### DIFF
--- a/tests/testthat/test-tax_range_strat.R
+++ b/tests/testthat/test-tax_range_strat.R
@@ -2,6 +2,7 @@ test_that("tax_range_strat() error handling", {
 
   occdf <- data.frame(genus = c("shrimp", "worm", "worm", "shrimp", "bivalve",
                                 "bivalve", "shrimp", "anemone", "worm"),
+                      group = c(A, B, B, A, A, A, A, B, B),
                       bed = c(1, 1, 2, 2, 2, 3, 3, 4, 4),
                       certainty = c(1, 1, 0, 1, 0, 1, 1, 1, 0))
 
@@ -13,6 +14,8 @@ test_that("tax_range_strat() error handling", {
   expect_error(tax_range_strat(occdf = occdf, certainty = 0))
   expect_error(tax_range_strat(occdf = occdf, certainty = "test"))
   expect_error(tax_range_strat(occdf = occdf, by = "test"))
+  expect_error(tax_range_strat(occdf = occdf, by = "group"))
+  expect_error(tax_range_strat(occdf = occdf, by = "group", group = "test"))
 
   occdf[1,1] <- NA;
   expect_error(tax_range_strat(occdf = occdf))

--- a/tests/testthat/test-tax_range_strat.R
+++ b/tests/testthat/test-tax_range_strat.R
@@ -2,7 +2,7 @@ test_that("tax_range_strat() error handling", {
 
   occdf <- data.frame(genus = c("shrimp", "worm", "worm", "shrimp", "bivalve",
                                 "bivalve", "shrimp", "anemone", "worm"),
-                      group = c(A, B, B, A, A, A, A, B, B),
+                      group = c("A", "B", "B", "A", "A", "A", "A", "B", "B"),
                       bed = c(1, 1, 2, 2, 2, 3, 3, 4, 4),
                       certainty = c(1, 1, 0, 1, 0, 1, 1, 1, 0))
 

--- a/tests/testthat/test-tax_range_time.R
+++ b/tests/testthat/test-tax_range_time.R
@@ -10,6 +10,8 @@ test_that("tax_range_time() works", {
   expect_true(is.data.frame(tax_range_time(occdf = occdf)))
   expect_true(is.data.frame(tax_range_time(occdf = occdf, by = "LAD")))
   expect_true(is.data.frame(tax_range_time(occdf = occdf, by = "name")))
+  expect_true(is.data.frame(tax_range_time(occdf = occdf, by = "group",
+                                           group = "class")))
 
   # Expect equal
   expect_equal(
@@ -24,6 +26,8 @@ test_that("tax_range_time() works", {
   expect_error(tax_range_time(occdf = occdf, max_ma = "test"))
   expect_error(tax_range_time(occdf = occdf, min_ma = "test"))
   expect_error(tax_range_time(occdf = occdf, by = "test"))
+  expect_error(tax_range_time(occdf = occdf, by = "group"))
+  expect_error(tax_range_time(occdf = occdf, by = "group", group = "test"))
   expect_error(tax_range_time(occdf = occdf, plot = "test"))
   expect_error(tax_range_time(occdf = occdf, name = "test"))
   expect_error(tax_range_time(occdf = occdf, plot_args = "test"))


### PR DESCRIPTION
This is a draft of new code corresponding to the request we received from @RussellGarwood. A grouping variable can now be supplied to either tax_range_time or tax_range_strat and used to sort the taxa.
I realised one issue which I'm not sure how to resolve, namely conflicts between the `name` and `group`. For example, what group does "cat" belong in, if the first row with a "cat" in says the cat belongs to "mammals", but the second row with a "cat" in says the cat belongs to "vertebrates". I set up the code to take the grouping from the first instance (smallest row number) of the taxon, with the grouping given in any other row ignored. This seems reasonable to me, but I think we should add a warning in the documentation if this is the approach we decide to take.