### PR TITLE
Use by and array2DF in group_apply

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 * Made bin durations more even and added n_bins option in time_bins (#131)
 * Added `autofit` argument to `axis_geo` which, when enabled, automatically adjusts the sizes of individual interval labels to fit within the interval boxes (#21)
 * Added `title` argument to `axis_geo` which can be used to add a title to the axis with the timescale (#133)
+* Increased efficiency and reduced hackiness of `group_apply` (#135)
 
 # palaeoverse 1.4.0
 

--- a/R/group_apply.R
+++ b/R/group_apply.R
@@ -22,7 +22,7 @@
 #' value (see examples).
 #'
 #' @return A \code{data.frame} of the outputs from the selected function, with
-#' appended column(s) indicating the user-defined groups. If a single vector
+#' prepended column(s) indicating the user-defined groups. If a single vector
 #' is returned via the called function, it will be transformed to a
 #' \code{data.frame} with the column name equal to the input function.
 #'
@@ -65,13 +65,13 @@
 #' ex1 <- group_apply(occdf = occdf, group = "cc", fun = nrow)
 #' # Unique genera per collection with group_apply and input arguments
 #' ex2 <- group_apply(occdf = occdf,
-#'                      group = c("collection_no"),
-#'                      fun = tax_unique,
-#'                      genus = "genus",
-#'                      family = "family",
-#'                      order = "order",
-#'                      class = "class",
-#'                      resolution = "genus")
+#'                    group = c("collection_no"),
+#'                    fun = tax_unique,
+#'                    genus = "genus",
+#'                    family = "family",
+#'                    order = "order",
+#'                    class = "class",
+#'                    resolution = "genus")
 #' # Use multiple variables (number of occurrences per collection and formation)
 #' ex3 <- group_apply(occdf = occdf,
 #'                    group = c("collection_no", "formation"),
@@ -85,7 +85,6 @@
 #' ex4 <- group_apply(occdf = occdf, group = "lat_bin", fun = nrow)
 #' @export
 group_apply <- function(occdf, group, fun, ...) {
-
   # Handle errors
   if (!is.data.frame(occdf)) {
     stop("`occdf` should be a dataframe")
@@ -110,39 +109,36 @@ group_apply <- function(occdf, group, fun, ...) {
                   " is not a valid argument for the specified function"))
     }
   }
-  # Generate bin codes
-  bin_codes <- as.formula(paste0("~ ", paste(group, collapse = " + ")))
-  # Split dataframe
-  lst <- split(occdf, f = bin_codes, drop = TRUE, sep = "&1*^$0%")
-  # Group names
-  nme <- names(lst)
-  # Split into individual columns
-  nme_df <- do.call(rbind.data.frame, strsplit(nme, "&1*^$0%", fixed = TRUE))
-  colnames(nme_df) <- group
-  # Apply function
-  output_lst <- lapply(lst, fun, ...)
-  # Function name
-  fun_name <- deparse(substitute(fun))
-  # Add groupings to output
-  output_df <- do.call(rbind.data.frame,
-                       lapply(seq_along(output_lst), FUN = function(i) {
-    df <- output_lst[[i]]
-    if (is.null(df)) return(df)
-    if (!is.data.frame(df)) {
-      df <- as.data.frame(df)
-      colnames(df) <- fun_name
-    }
-    if (!is.null(nrow(df)) && nrow(df) > 0) {
-      nms <- c(colnames(df), colnames(nme_df))
-      df <- cbind.data.frame(df, nme_df[i, , drop = TRUE])
-      colnames(df) <- nms
-      df
-    }
-  }))
+  # Generate formula
+  form <- as.formula(paste0("~ ", paste(group, collapse = " + ")))
+
+  # by is a wrapper of tapply, but it ends up being MUCH faster than tapply
+  # because of some data wrangling it does
+  output_lst <- by(occdf, form, fun, ...)
+
+  if (is.list(output_lst)) {
+    # modified from array2DF() to handle when functions return empty dfs
+    keys <- do.call(expand.grid, c(dimnames(provideDimnames(output_lst)),
+                                   KEEP.OUT.ATTRS = FALSE,
+                                   stringsAsFactors = FALSE))
+    # filter out NULLs
+    output_lst_keep <- vapply(output_lst, Negate(is.null), FALSE)
+    output_lst <- output_lst[output_lst_keep]
+    dfrows <- vapply(output_lst, nrow, 1L)
+    keys <- keys[output_lst_keep, , drop = FALSE]
+    output_df <- cbind(keys[rep(seq_along(dfrows), dfrows), , drop = FALSE],
+                       do.call(rbind, output_lst))
+  } else {
+    fun_name <- deparse(substitute(fun))
+    output_df <- array2DF(output_lst, responseName = fun_name)
+    output_df <- output_df[!is.na(output_df[, fun_name]), ]
+  }
+
   # Update output if none returned
   if (nrow(output_df) == 0) {
     output_df <- NULL
   }
+
   # Return output
   return(output_df)
 }

--- a/man/group_apply.Rd
+++ b/man/group_apply.Rd
@@ -28,7 +28,7 @@ value (see examples).}
 }
 \value{
 A \code{data.frame} of the outputs from the selected function, with
-appended column(s) indicating the user-defined groups. If a single vector
+prepended column(s) indicating the user-defined groups. If a single vector
 is returned via the called function, it will be transformed to a
 \code{data.frame} with the column name equal to the input function.
 }
@@ -84,13 +84,13 @@ occdf <- subset(occdf, !is.na(genus))
 ex1 <- group_apply(occdf = occdf, group = "cc", fun = nrow)
 # Unique genera per collection with group_apply and input arguments
 ex2 <- group_apply(occdf = occdf,
-                     group = c("collection_no"),
-                     fun = tax_unique,
-                     genus = "genus",
-                     family = "family",
-                     order = "order",
-                     class = "class",
-                     resolution = "genus")
+                   group = c("collection_no"),
+                   fun = tax_unique,
+                   genus = "genus",
+                   family = "family",
+                   order = "order",
+                   class = "class",
+                   resolution = "genus")
 # Use multiple variables (number of occurrences per collection and formation)
 ex3 <- group_apply(occdf = occdf,
                    group = c("collection_no", "formation"),


### PR DESCRIPTION
This speeds up `group_apply` by using the built-in `by` and `array2DF` functions. By switching to these built-in functions, we also remove the hackiness related to using a custom splitting string.

Here's some benchmarking of the existing palaeoverse implementation of group_apply and the implementation in this PR:
![image](https://github.com/user-attachments/assets/853c7a68-4a32-4641-baa0-c0545b274fa1)

![image](https://github.com/user-attachments/assets/d94124ff-8261-4a9b-b60f-fd95aa1ad831)

Fixes #135.