### PR TITLE
Rework tests for `tax_certainty()`

### DIFF
--- a/R/tax_certainty.R
+++ b/R/tax_certainty.R
@@ -119,7 +119,7 @@ tax_certainty <- function(
     stop("`terms` must be of class list or NULL.")
   }
   # Check for valid append input
-  if (!is.logical(append)) {
+  if (is.na(append) || !is.logical(append)) {
     stop("`append` must be of class logical (TRUE/FALSE).")
   }
   # Create temporary taxdf column to not replace original values

--- a/tests/testthat/_snaps/tax_certainty.md
+++ b/tests/testthat/_snaps/tax_certainty.md
@@ -43,6 +43,6 @@
     Code
       tax_certainty(taxdf = occdf, name = "identified_name", append = NA)
     Condition
-      Error in `if (!append) ...`:
-      ! missing value where TRUE/FALSE needed
+      Error in `tax_certainty()`:
+      ! `append` must be of class logical (TRUE/FALSE).
 

--- a/tests/testthat/_snaps/tax_certainty.md
+++ b/tests/testthat/_snaps/tax_certainty.md
@@ -1,0 +1,48 @@
+# tax_certainty() basic behavior
+
+    Code
+      tax_certainty(taxdf = data.frame(), name = "identified_name")
+    Condition
+      Error in `tax_certainty()`:
+      ! `names` is not a named column in `taxdf`.
+
+# arg 'name' works
+
+    Code
+      tax_certainty(taxdf = occdf, name = "foo")
+    Condition
+      Error in `tax_certainty()`:
+      ! `names` is not a named column in `taxdf`.
+
+---
+
+    Code
+      tax_certainty(taxdf = occdf, name = NULL)
+    Condition
+      Error in `.subset2()`:
+      ! attempt to select less than one element in get1index
+
+# arg 'terms' works
+
+    Code
+      tax_certainty(taxdf = occdf, name = "identified_name", terms = 1)
+    Condition
+      Error in `tax_certainty()`:
+      ! `terms` must be of class list or NULL.
+
+# arg 'append' works
+
+    Code
+      tax_certainty(taxdf = occdf, name = "identified_name", append = 1)
+    Condition
+      Error in `tax_certainty()`:
+      ! `append` must be of class logical (TRUE/FALSE).
+
+---
+
+    Code
+      tax_certainty(taxdf = occdf, name = "identified_name", append = NA)
+    Condition
+      Error in `if (!append) ...`:
+      ! missing value where TRUE/FALSE needed
+

--- a/tests/testthat/test-tax_certainty.R
+++ b/tests/testthat/test-tax_certainty.R
@@ -1,74 +1,156 @@
-test_that("tax_certainty() works", {
+test_that("tax_certainty() basic behavior", {
   data("tetrapods")
-  # Error handling
-  expect_error(tax_certainty(vector()))
-  expect_error(tax_certainty(NULL))
-  expect_error(tax_certainty(
-    taxdf = tetrapods$identified_name,
-    certainty = c("certain", "uncertain"),
-    append = FALSE
-  ))
-  expect_error(tax_certainty(
-    taxdf = tetrapods,
-    name = "accepted_name",
-    terms = "subspecies",
-    append = FALSE
-  ))
-  expect_error(tax_certainty(taxdf = tetrapods, name = "test", append = FALSE))
-  expect_error(tax_certainty(taxdf = tetrapods, name = 1, append = FALSE))
-  expect_error(tax_certainty(
-    taxdf = tetrapods,
-    name = "accepted_name",
-    append = 99
-  ))
-  # Expect true
-  ## Vector returned
-  expect_true(is.data.frame(tax_certainty(
-    taxdf = tetrapods,
-    name = "accepted_name",
-    append = FALSE
-  )))
-  ## Dataframe returned
-  expect_true(is.data.frame(tax_certainty(
-    taxdf = tetrapods,
-    name = "accepted_name",
-    append = TRUE
-  )))
-  ## Custom certainty
-  expect_true(is.logical(
-    tax_certainty(
-      taxdf = tetrapods,
-      name = "accepted_name",
-      certainty = c(TRUE, FALSE),
-      append = FALSE
-    )$certainty
-  ))
-  ## Certainty appended correctly
-  expect_true(
-    "certainty" %in%
-      colnames(tax_certainty(
-        taxdf = tetrapods,
-        name = "accepted_name",
-        append = TRUE
-      ))
-  )
-  ## Custom terms
-  expect_true(is.data.frame(tax_certainty(
-    taxdf = tetrapods,
-    name = "genus",
-    terms = list(custom = "test"),
-    append = FALSE
-  )))
-
-  ## Correct number of certain/uncertainty values returned
+  occdf <- tetrapods[1:5, ]
   expect_equal(
-    3759,
-    sum(
-      tax_certainty(
-        taxdf = tetrapods,
-        name = "family",
-        append = FALSE
-      )$certainty
+    tax_certainty(taxdf = occdf, name = "identified_name"),
+    cbind(occdf, data.frame(certainty = c(1, 0, 1, 1, 1)))
+  )
+
+  # input checks
+  expect_snapshot(
+    tax_certainty(taxdf = data.frame(), name = "identified_name"),
+    error = TRUE
+  )
+})
+
+test_that("arg 'name' works", {
+  data("tetrapods")
+  occdf <- tetrapods[1:5, "identified_name", drop = FALSE]
+  colnames(occdf) <- "new_name"
+
+  expect_equal(
+    tax_certainty(taxdf = occdf, name = "new_name"),
+    cbind(occdf, data.frame(certainty = c(1, 0, 1, 1, 1)))
+  )
+
+  # input checks
+  expect_snapshot(
+    tax_certainty(taxdf = occdf, name = "foo"),
+    error = TRUE
+  )
+  expect_snapshot(
+    tax_certainty(taxdf = occdf, name = NULL),
+    error = TRUE
+  )
+
+  # TODO: this should error, docs say this should be a column name, not a column index
+  # expect_snapshot(
+  #   tax_certainty(taxdf = occdf, name = 1),
+  #   error = TRUE
+  # )
+})
+
+test_that("arg 'terms' works", {
+  data("tetrapods")
+  occdf <- tetrapods[1:5, "identified_name", drop = FALSE]
+
+  # "Broiliellus n. sp. arroyoensis" and "n. gen. Ophiodeirus n. sp. casei"
+  # now become uncertain
+  expect_equal(
+    tax_certainty(
+      taxdf = occdf,
+      name = "identified_name",
+      terms = list(
+        species = "Broiliellus n. sp. arroyoensis",
+        genus = "Ophiodeirus"
+      )
+    ),
+    cbind(occdf, data.frame(certainty = c(1, 0, 1, 0, 0)))
+  )
+
+  # input checks
+  expect_snapshot(
+    tax_certainty(taxdf = occdf, name = "identified_name", terms = 1),
+    error = TRUE
+  )
+
+  # TODO: should error
+  # expect_snapshot(
+  #   tax_certainty(taxdf = occdf, name = "identified_name", terms = list(1)),
+  #   error = TRUE
+  # )
+
+  # TODO: should error
+  # expect_snapshot(
+  #   tax_certainty(taxdf = occdf, name = "identified_name", terms = list(a = 1)),
+  #   error = TRUE
+  # )
+})
+
+test_that("arg 'certainty' works", {
+  data("tetrapods")
+  occdf <- tetrapods[1:5, ]
+
+  expect_equal(
+    tax_certainty(
+      taxdf = occdf,
+      name = "identified_name",
+      certainty = c("A", "B")
+    ),
+    cbind(occdf, data.frame(certainty = c("A", "B", "A", "A", "A")))
+  )
+
+  # check mixing character and numeric
+  expect_equal(
+    tax_certainty(
+      taxdf = occdf,
+      name = "identified_name",
+      certainty = c("A", 0)
+    ),
+    cbind(occdf, data.frame(certainty = c("A", "0", "A", "A", "A")))
+  )
+
+  # input checks
+
+  # TODO: both tests below should error - docs say "A vector of length two denoting how
+  # certainty should be coded."
+  #
+  # expect_snapshot(
+  #   tax_certainty(taxdf = occdf, name = "identified_name", certainty = "A"),
+  #   error = TRUE
+  # )
+  # expect_snapshot(
+  #   tax_certainty(taxdf = occdf, name = "identified_name", certainty = c("A", "B", "C")),
+  #   error = TRUE
+  # )
+
+  # TODO: should error, this doesn't return the column "certainty"
+  # expect_snapshot(
+  #   tax_certainty(taxdf = occdf, name = "identified_name", certainty = NULL),
+  #   error = TRUE
+  # )
+
+  # TODO: should error, this returns 1 everywhere
+  # expect_snapshot(
+  #   tax_certainty(taxdf = occdf, name = "identified_name", certainty = c(1, 1)),
+  #   error = TRUE
+  # )
+})
+
+test_that("arg 'append' works", {
+  data("tetrapods")
+  occdf <- tetrapods[1:5, c("identified_name", "life_habit")]
+
+  expect_equal(
+    tax_certainty(
+      taxdf = occdf,
+      name = "identified_name",
+      append = FALSE
+    ),
+    cbind(
+      occdf[, "identified_name", drop = FALSE],
+      data.frame(certainty = c(1, 0, 1, 1, 1))
     )
+  )
+
+  # input checks
+
+  expect_snapshot(
+    tax_certainty(taxdf = occdf, name = "identified_name", append = 1),
+    error = TRUE
+  )
+  expect_snapshot(
+    tax_certainty(taxdf = occdf, name = "identified_name", append = NA),
+    error = TRUE
   )
 })


### PR DESCRIPTION
This PR revamps tests for `tax_certainty()`. It:

*  splits tests into more test_that() code blocks
*  adds more tests with wrong inputs
* checks more values

There are many `# TODO` but I don't think we need to discuss them, they all seem pretty clear to me.

Part of https://github.com/palaeoverse/palaeoverse/issues/161



## Checklist before requesting a review
- [x] I have read palaeoverse's [standards and structure](https://palaeoverse.palaeoverse.org/articles/structure-and-standards.html)
- [x] I have performed a self-review of my code.
- [ ] I have added function documentation.
- [ ] I have provided sufficient examples of implementation.
- [ ] If it is a core feature, I have added thorough tests.

