### PR TITLE
Rework tests for `tax_check()`

### DIFF
--- a/tests/testthat/_snaps/tax_check.md
+++ b/tests/testthat/_snaps/tax_check.md
@@ -1,33 +1,7 @@
-# tax_check() accepts taxon names, no groups
+# arg 'name' works
 
     Code
-      tax_check(name = "genus", group = TRUE)
-    Condition
-      Error in `tax_check()`:
-      ! argument "taxdf" is missing, with no default
-
----
-
-    Code
-      tax_check(1)
-    Condition
-      Error in `tax_check()`:
-      ! Please supply `taxdf` as a data.frame with named columns, containing
-               taxon names, and optionally their higher classification
-
----
-
-    Code
-      tax_check(data.frame())
-    Condition
-      Error in `tax_check()`:
-      ! Please supply `taxdf` as a data.frame with named columns, containing
-               taxon names, and optionally their higher classification
-
----
-
-    Code
-      tax_check(testdf, name = 1)
+      tax_check(dat)
     Condition
       Error in `tax_check()`:
       ! Please specify `name` as a single column name in `taxdf`
@@ -35,7 +9,7 @@
 ---
 
     Code
-      tax_check(testdf, name = c("one", "name"))
+      tax_check(dat, name = "nonexistent")
     Condition
       Error in `tax_check()`:
       ! Please specify `name` as a single column name in `taxdf`
@@ -43,16 +17,39 @@
 ---
 
     Code
-      tax_check(testdf, name = "age")
+      tax_check(dat, name = 1)
     Condition
       Error in `tax_check()`:
-      ! The `name` column in `taxdf` must contain data of class character and
-               at least one entry that is not NA or empty
+      ! Please specify `name` as a single column name in `taxdf`
 
 ---
 
     Code
-      tax_check(testdf, "genus", group = TRUE)
+      tax_check(dat, name = NULL)
+    Condition
+      Error in `tax_check()`:
+      ! Please specify `name` as a single column name in `taxdf`
+
+---
+
+    Code
+      tax_check(dat, name = character(0))
+    Condition
+      Error in `tax_check()`:
+      ! Please specify `name` as a single column name in `taxdf`
+
+---
+
+    Code
+      tax_check(dat, name = "")
+    Condition
+      Error in `tax_check()`:
+      ! Please specify `name` as a single column name in `taxdf`
+
+# arg 'group' works
+
+    Code
+      tax_check(dat, group = "nonexistent")
     Condition
       Error in `tax_check()`:
       ! Please specify `group` as a single column name in `taxdf`
@@ -60,7 +57,7 @@
 ---
 
     Code
-      tax_check(testdf, "genus", group = c("a", "group"))
+      tax_check(dat, group = 1)
     Condition
       Error in `tax_check()`:
       ! Please specify `group` as a single column name in `taxdf`
@@ -68,7 +65,7 @@
 ---
 
     Code
-      tax_check(testdf, "genus", group = "agroup")
+      tax_check(dat, group = character(0))
     Condition
       Error in `tax_check()`:
       ! Please specify `group` as a single column name in `taxdf`
@@ -76,23 +73,15 @@
 ---
 
     Code
-      tax_check(testdf, "genus", group = "age")
+      tax_check(dat, group = "")
     Condition
       Error in `tax_check()`:
-      ! The `group` column in `taxdf` must contain data of class character
+      ! Please specify `group` as a single column name in `taxdf`
 
----
-
-    Code
-      tax_check(testdf, "genus", dis = "max")
-    Condition
-      Error in `tax_check()`:
-      ! `dis` must be a single numeric, greater than 0 and less than 1
-
----
+# arg 'dis' works
 
     Code
-      tax_check(testdf, "genus", dis = 0)
+      tax_check(dat, dis = 1)
     Condition
       Error in `tax_check()`:
       ! `dis` must be a single numeric, greater than 0 and less than 1
@@ -100,7 +89,7 @@
 ---
 
     Code
-      tax_check(testdf, "genus", dis = FALSE)
+      tax_check(dat, dis = 0)
     Condition
       Error in `tax_check()`:
       ! `dis` must be a single numeric, greater than 0 and less than 1
@@ -108,7 +97,31 @@
 ---
 
     Code
-      tax_check(testdf, "genus", start = "1")
+      tax_check(dat, dis = "a")
+    Condition
+      Error in `tax_check()`:
+      ! `dis` must be a single numeric, greater than 0 and less than 1
+
+---
+
+    Code
+      tax_check(dat, dis = numeric(0))
+    Condition
+      Error in `tax_check()`:
+      ! `dis` must be a single numeric, greater than 0 and less than 1
+
+---
+
+    Code
+      tax_check(dat, dis = NULL)
+    Condition
+      Error in `tax_check()`:
+      ! `dis` must be a single numeric, greater than 0 and less than 1
+
+# arg 'start' works
+
+    Code
+      tax_check(dat, start = -1)
     Condition
       Error in `tax_check()`:
       ! `start` must be a single positive integer, or zero
@@ -116,7 +129,7 @@
 ---
 
     Code
-      tax_check(testdf, "genus", start = c(1, 3))
+      tax_check(dat, start = numeric(0))
     Condition
       Error in `tax_check()`:
       ! `start` must be a single positive integer, or zero
@@ -124,15 +137,39 @@
 ---
 
     Code
-      tax_check(testdf, "genus", start = TRUE)
+      tax_check(dat, start = "a")
     Condition
       Error in `tax_check()`:
       ! `start` must be a single positive integer, or zero
 
+# arg 'verbose' works
+
+    Code
+      tax_check(dat, verbose = 1)
+    Condition
+      Error in `tax_check()`:
+      ! `verbose` must be a single logical value
+
 ---
 
     Code
-      tax_check(testdf, "genus", verbose = "TRUE")
+      tax_check(dat, verbose = numeric(0))
+    Condition
+      Error in `tax_check()`:
+      ! `verbose` must be a single logical value
+
+---
+
+    Code
+      tax_check(dat, verbose = "a")
+    Condition
+      Error in `tax_check()`:
+      ! `verbose` must be a single logical value
+
+---
+
+    Code
+      tax_check(dat, verbose = NULL)
     Condition
       Error in `tax_check()`:
       ! `verbose` must be a single logical value

--- a/tests/testthat/_snaps/tax_check.md
+++ b/tests/testthat/_snaps/tax_check.md
@@ -1,3 +1,21 @@
+# basic behavior works
+
+    Code
+      tax_check(data.frame())
+    Condition
+      Error in `tax_check()`:
+      ! Please supply `taxdf` as a data.frame with named columns, containing
+               taxon names, and optionally their higher classification
+
+---
+
+    Code
+      tax_check(1)
+    Condition
+      Error in `tax_check()`:
+      ! Please supply `taxdf` as a data.frame with named columns, containing
+               taxon names, and optionally their higher classification
+
 # arg 'name' works
 
     Code

--- a/tests/testthat/test-tax_check.R
+++ b/tests/testthat/test-tax_check.R
@@ -1,61 +1,217 @@
-testdf <- data.frame(
-  family = c(
-    "Examplidae",
-    "Examplidae",
-    "Taxonidae",
-    NA,
-    "Taxonidae",
-    "Examplidae",
-    "Examplidae",
-    "Examplidae",
-    "Examplidae",
-    "Taxonidae",
-    "Taxonidae"
-  ),
-  genus = c(
-    "Joebloggsia",
-    "Joebloggia",
-    "Facsimilus",
-    "Imperfectella",
-    "Automaton",
-    NA,
-    "Joebloggsia",
-    "Shangrilaria",
-    "Shangirlaria",
-    "Kunlungoides",
-    "Kunlungoides.sp"
-  ),
-  age = c(1:11)
-)
-
-# test errors from incorrectly supplied arguments, and warnings
-test_that("tax_check() accepts taxon names, no groups", {
-  # not data.frame or zero length data.frame supplied
-  expect_snapshot(tax_check(name = "genus", group = TRUE), error = TRUE)
-  expect_snapshot(tax_check(1), error = TRUE)
-  expect_snapshot(tax_check(data.frame()), error = TRUE)
-  # name column not/incorrectly specified
-  expect_snapshot(tax_check(testdf, name = 1), error = TRUE)
-  expect_snapshot(tax_check(testdf, name = c("one", "name")), error = TRUE)
-  expect_snapshot(tax_check(testdf, name = "age"), error = TRUE)
-  # groups column incorrectly specified
-  expect_snapshot(tax_check(testdf, "genus", group = TRUE), error = TRUE)
-  expect_snapshot(
-    tax_check(testdf, "genus", group = c("a", "group")),
-    error = TRUE
+test_that("basic behavior works", {
+  dat <- data.frame(
+    genus = c(
+      "Automaton",
+      "Joebloggsia",
+      "Facsimilus",
+      "Joebloggia",
+      "Facsimilu",
+      "Facsimilu",
+      NA
+    )
   )
-  expect_snapshot(tax_check(testdf, "genus", group = "agroup"), error = TRUE)
-  expect_snapshot(tax_check(testdf, "genus", group = "age"), error = TRUE)
-  # Jaro distance out of range 0-1
-  expect_snapshot(tax_check(testdf, "genus", dis = "max"), error = TRUE)
-  expect_snapshot(tax_check(testdf, "genus", dis = 0), error = TRUE)
-  expect_snapshot(tax_check(testdf, "genus", dis = FALSE), error = TRUE)
-  # start/end letter matches incorrectly supplied
-  expect_snapshot(tax_check(testdf, "genus", start = "1"), error = TRUE)
-  expect_snapshot(tax_check(testdf, "genus", start = c(1, 3)), error = TRUE)
-  expect_snapshot(tax_check(testdf, "genus", start = TRUE), error = TRUE)
-  # verbosity not logical
-  expect_snapshot(tax_check(testdf, "genus", verbose = "TRUE"), error = TRUE)
-  # non alpha character warning
-  expect_warning(tax_check(testdf, "genus", verbose = TRUE))
+  expect_equal(
+    tax_check(dat),
+    list(
+      synonyms = data.frame(
+        group = c("F", "J"),
+        greater = c("Facsimilu", "Joebloggsia"),
+        lesser = c("Facsimilus", "Joebloggia"),
+        count_greater = c(2, 1),
+        count_lesser = 1
+      ),
+      non_letter_name = NULL,
+      non_letter_group = NULL
+    )
+  )
+})
+
+test_that("arg 'name' works", {
+  dat <- data.frame(
+    foo = c(
+      "Automaton",
+      "Joebloggsia",
+      "Facsimilus",
+      "Joebloggia",
+      "Facsimilu",
+      "Facsimilu",
+      NA
+    )
+  )
+
+  # default name is "genus"
+  expect_snapshot(tax_check(dat), error = TRUE)
+
+  expect_equal(
+    tax_check(dat, name = "foo"),
+    list(
+      synonyms = data.frame(
+        group = c("F", "J"),
+        greater = c("Facsimilu", "Joebloggsia"),
+        lesser = c("Facsimilus", "Joebloggia"),
+        count_greater = c(2, 1),
+        count_lesser = 1
+      ),
+      non_letter_name = NULL,
+      non_letter_group = NULL
+    )
+  )
+
+  # input checks
+  expect_snapshot(tax_check(dat, name = "nonexistent"), error = TRUE)
+  expect_snapshot(tax_check(dat, name = 1), error = TRUE)
+  expect_snapshot(tax_check(dat, name = NULL), error = TRUE)
+  expect_snapshot(tax_check(dat, name = character(0)), error = TRUE)
+  expect_snapshot(tax_check(dat, name = ""), error = TRUE)
+})
+
+test_that("arg 'group' works", {
+  dat <- data.frame(
+    family = c(
+      "Foo",
+      "Examplidae",
+      "Examplidae",
+      "Examplidae",
+      "Taxonidae"
+    ),
+    genus = c(
+      "Joebloggsia",
+      "Joebloggia",
+      "Facsimilus",
+      "Facsimilu",
+      "Facsimilu"
+    )
+  )
+
+  # Without "group", we would have two groups "F" and "J"
+  expect_equal(
+    tax_check(dat, group = "family"),
+    list(
+      synonyms = data.frame(
+        group = "Examplidae",
+        greater = "Facsimilu",
+        lesser = "Facsimilus",
+        count_greater = 2L,
+        count_lesser = 1L
+      ),
+      non_letter_name = NULL,
+      non_letter_group = NULL
+    )
+  )
+
+  # input checks
+  expect_snapshot(tax_check(dat, group = "nonexistent"), error = TRUE)
+  expect_snapshot(tax_check(dat, group = 1), error = TRUE)
+  expect_snapshot(tax_check(dat, group = character(0)), error = TRUE)
+  expect_snapshot(tax_check(dat, group = ""), error = TRUE)
+})
+
+test_that("arg 'dis' works", {
+  dat <- data.frame(
+    genus = c(
+      "Automaton",
+      "Joebloggsia",
+      "Facsimilus",
+      "Joebloggia",
+      "Facsimilu",
+      "Facstlwe",
+      NA
+    )
+  )
+
+  expect_equal(
+    tax_check(dat, dis = 0.5),
+    list(
+      synonyms = data.frame(
+        group = c("F", "F", "F", "J"),
+        greater = c("Facsimilu", "Facsimilus", "Facsimilus", "Joebloggsia"),
+        lesser = c("Facstlwe", "Facsimilu", "Facstlwe", "Joebloggia"),
+        count_greater = 1L,
+        count_lesser = 1L
+      ),
+      non_letter_name = NULL,
+      non_letter_group = NULL
+    )
+  )
+
+  # input checks
+  expect_snapshot(tax_check(dat, dis = 1), error = TRUE)
+  expect_snapshot(tax_check(dat, dis = 0), error = TRUE)
+  expect_snapshot(tax_check(dat, dis = "a"), error = TRUE)
+  expect_snapshot(tax_check(dat, dis = numeric(0)), error = TRUE)
+  expect_snapshot(tax_check(dat, dis = NULL), error = TRUE)
+})
+
+test_that("arg 'start' works", {
+  dat <- data.frame(
+    genus = c(
+      "Automaton",
+      "Kunlungoides sp",
+      "Kunmungoides sp",
+      NA
+    )
+  )
+
+  # "Kunlungoides sp" and "Kunmungoides sp" are reported as synonyms
+  expect_equal(
+    tax_check(dat),
+    list(
+      synonyms = data.frame(
+        group = "K",
+        greater = "Kunlungoides sp",
+        lesser = "Kunmungoides sp",
+        count_greater = 1L,
+        count_lesser = 1L
+      ),
+      non_letter_name = NULL,
+      non_letter_group = NULL
+    )
+  )
+
+  # The letter that diverges for "Kunlungoides sp" and "Kunmungoides sp" is the 4th one
+  # so this synonym isn't reported if start >= 4
+  expect_equal(
+    tax_check(dat, start = 4),
+    list(
+      synonyms = NULL,
+      non_letter_name = NULL,
+      non_letter_group = NULL
+    )
+  )
+
+  # input checks
+  expect_snapshot(tax_check(dat, start = -1), error = TRUE)
+  expect_snapshot(tax_check(dat, start = numeric(0)), error = TRUE)
+  expect_snapshot(tax_check(dat, start = "a"), error = TRUE)
+
+  # TODO: should error
+  # expect_snapshot(tax_check(dat, start = NULL), error = TRUE)
+})
+
+test_that("arg 'verbose' works", {
+  dat <- data.frame(
+    genus = c(
+      "Automaton",
+      "Kunlungoides sp",
+      "Kunmungoides sp",
+      NA
+    )
+  )
+
+  expect_equal(
+    tax_check(dat, verbose = FALSE),
+    data.frame(
+      group = "K",
+      greater = "Kunlungoides sp",
+      lesser = "Kunmungoides sp",
+      count_greater = 1L,
+      count_lesser = 1L
+    )
+  )
+
+  # input checks
+  expect_snapshot(tax_check(dat, verbose = 1), error = TRUE)
+  expect_snapshot(tax_check(dat, verbose = numeric(0)), error = TRUE)
+  expect_snapshot(tax_check(dat, verbose = "a"), error = TRUE)
+  expect_snapshot(tax_check(dat, verbose = NULL), error = TRUE)
 })

--- a/tests/testthat/test-tax_check.R
+++ b/tests/testthat/test-tax_check.R
@@ -24,6 +24,10 @@ test_that("basic behavior works", {
       non_letter_group = NULL
     )
   )
+
+  # input checks
+  expect_snapshot(tax_check(data.frame()), error = TRUE)
+  expect_snapshot(tax_check(1), error = TRUE)
 })
 
 test_that("arg 'name' works", {


### PR DESCRIPTION
This PR revamps tests for `tax_check()`. It:

*  splits tests into more test_that() code blocks
*  adds more tests with wrong inputs
* checks more values

Part of https://github.com/palaeoverse/palaeoverse/issues/161



## Checklist before requesting a review
- [x] I have read palaeoverse's [standards and structure](https://palaeoverse.palaeoverse.org/articles/structure-and-standards.html)
- [x] I have performed a self-review of my code.
- [ ] I have added function documentation.
- [ ] I have provided sufficient examples of implementation.
- [ ] If it is a core feature, I have added thorough tests.

