### PR TITLE
Make the `allcontributors` CI workflow open a PR if needed

### DIFF
--- a/.github/workflows/allcontributors.yml
+++ b/.github/workflows/allcontributors.yml
@@ -8,6 +8,10 @@ on:
 
 name: Update allcontributors
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
 
   allcontributors:
@@ -35,9 +39,14 @@ jobs:
       - name: Update allcontributors
         run: Rscript -e 'allcontributors::add_contributors(ncols = 5, num_sections = 1)'
 
-      - name: Commit results
-        run: |
-          git config user.name  "Github Actions"
-          git config user.email "github-actions@github.com"
-          git commit README.md -m 'Update allcontributors on README.md' || echo "No changes to commit"
-          git push https://${{github.actor}}:${{secrets.GITHUB_TOKEN}}@github.com/${{github.repository}}.git HEAD:${{ github.ref }} || echo "No changes to commit"
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7
+        with:
+          commit-message: 'Update allcontributors in README.md'
+          author: 'Github Actions <github-actions@github.com>'
+          committer: 'Github Actions <github-actions@github.com>'
+          branch: update-allcontributors
+          delete-branch: true
+          title: 'Update allcontributors in README.md'
+          body: 'Automated update of the contributors list in README.md.'
+          add-paths: README.md


### PR DESCRIPTION
This workflow used to fail when it needed to make changes because it cannot push to `main` directly:

```
 [main 899751f] Update allcontributors on README.md
 1 file changed, 14 insertions(+), 6 deletions(-)
remote: error: GH006: Protected branch update failed for refs/heads/main.        
remote: 
remote: - Changes must be made through a pull request.        
remote: 
remote: - 8 of 8 required status checks are expected.        
To https://github.com/palaeoverse/palaeoverse.git
 ! [remote rejected] HEAD -> main (protected branch hook declined)
error: failed to push some refs to 'https://github.com/palaeoverse/palaeoverse.git'
No changes to commit
```

This PR modifies the workflow so that it opens a PR when there are any changes to make.

## Checklist before requesting a review
- [x] I have read palaeoverse's [standards and structure](https://palaeoverse.palaeoverse.org/articles/structure-and-standards.html)
- [x] I have performed a self-review of my code.
- [ ] I have added function documentation.
- [ ] I have provided sufficient examples of implementation.
- [ ] If it is a core feature, I have added thorough tests.

