### PR TITLE
Update `peter-evans/create-pull-request` step in `allcontributors` workflow

### DIFF
--- a/.github/workflows/allcontributors.yml
+++ b/.github/workflows/allcontributors.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
 
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - uses: r-lib/actions/setup-pandoc@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2
 
@@ -40,7 +42,7 @@ jobs:
         run: Rscript -e 'allcontributors::add_contributors(ncols = 5, num_sections = 1)'
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8
         with:
           commit-message: 'Update allcontributors in README.md'
           author: 'Github Actions <github-actions@github.com>'

--- a/.github/workflows/allcontributors.yml
+++ b/.github/workflows/allcontributors.yml
@@ -26,8 +26,6 @@ jobs:
     steps:
 
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          persist-credentials: false
 
       - uses: r-lib/actions/setup-pandoc@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2
 


### PR DESCRIPTION
Yet another PR for the `allcontributors` workflow, which is [failing](https://github.com/palaeoverse/palaeoverse/actions/runs/29812203248/job/88575454784) with this error message:

```
  Working base is branch 'main'
  /usr/bin/git remote prune origin
  remote: Duplicate header: "Authorization"
  fatal: unable to access 'https://github.com/palaeoverse/palaeoverse/': The requested URL returned error: 400
  Error: The process '/usr/bin/git' failed with exit code 128
```

This was actually fixed in more recent versions of `peter-evans/create-pull-request`:

- https://github.com/peter-evans/create-pull-request/issues/4228
- https://github.com/peter-evans/create-pull-request/issues/4272

Using the latest version of this step should work fine.

Followup of #269 

## Checklist before requesting a review
- [x] I have read palaeoverse's [standards and structure](https://palaeoverse.palaeoverse.org/articles/structure-and-standards.html)
- [x] I have performed a self-review of my code.
- [ ] I have added function documentation.
- [ ] I have provided sufficient examples of implementation.
- [ ] If it is a core feature, I have added thorough tests.

