### PR TITLE
`allcontributors` workflow: Add token with permission to create a PR

### DIFF
--- a/.github/workflows/allcontributors.yml
+++ b/.github/workflows/allcontributors.yml
@@ -50,3 +50,4 @@ jobs:
           title: 'Update allcontributors in README.md'
           body: 'Automated update of the contributors list in README.md.'
           add-paths: README.md
+          token: ${{ secrets.ALLCONTRIBUTORS_PAT }}


### PR DESCRIPTION
This workflow is [failing](https://github.com/palaeoverse/palaeoverse/actions/runs/29905097165/job/88874523393#step:7:109)  with:

```
  Create or update the pull request
    Attempting creation of pull request
    Error: GitHub Actions is not permitted to create or approve pull requests. - https://docs.github.com/rest/pulls/pulls#create-a-pull-request
```

I added a PAT with the permission to create a PR in the repository secrets, and this PR gives this secret to the `allcontributors` workflow.

Followup of #271.