### PR TITLE
`pkgdown`: Update links check to handle the "development" mode

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -33,8 +33,17 @@ jobs:
           extra-packages: any::pkgdown, any::brand.yml, local::.
           needs: website
 
+      # We use `development: mode: auto` in the pkgdown template, so the website can get 
+      # deployed to "docs" or "docs/dev" depending on the development mode. This means that
+      # we need to record this information in GITHUB_ENV so that lychee can access it later. 
       - name: Build site
-        run: pkgdown::build_site_github_pages(new_process = FALSE, install = FALSE)
+        run: |
+          pkgdown::build_site_github_pages(new_process = FALSE, install = FALSE)
+          pkg <- pkgdown::as_pkgdown(".")
+          cat(
+            paste0("SITE_DIR=", pkg$dst_path, "\nSITE_PREFIX=", pkg$prefix, "\n"),
+            file = Sys.getenv("GITHUB_ENV"), append = TRUE
+          )
         shell: Rscript {0}
 
       # This is almost the same call as in check-links.yaml but this time we run it on the 
@@ -54,9 +63,10 @@ jobs:
         uses: lycheeverse/lychee-action@39066c6d1f0de280863a3760160617e188b607ad # v2
         with:
           args: |
-            docs
-            --root-dir=${{ github.workspace }}/docs
-            --remap 'https://palaeoverse\.palaeoverse\.org/(.*) file://${{ github.workspace }}/docs/$1'
+            ${{ env.SITE_DIR }}
+            --root-dir=${{ env.SITE_DIR }}
+            --remap 'https://palaeoverse\.palaeoverse\.org/${{ env.SITE_PREFIX }}(.*) file://${{ env.SITE_DIR }}/$1'
+            --remap 'https://palaeoverse\.palaeoverse\.org/(.*) file://${{ env.SITE_DIR }}/$1'
             --remap 'https://github\.com/palaeoverse/palaeoverse/blob/HEAD/(.*) file://${{ github.workspace }}/$1'
             --max-concurrency 4
             --max-retries 5


### PR DESCRIPTION
Fixes https://github.com/palaeoverse/palaeoverse/issues/285.

The `pkgdown` workflow now deploys the website to either "palaeoverse.palaeoverse.org" or "palaeoverse.palaeoverse.org/dev", meaning that the links check that happens in the same workflow needs to be updated to correctly remap the links that contain "palaeoverse.palaeoverse.org/dev".

## Checklist before requesting a review
- [x] I have read palaeoverse's [standards and structure](https://palaeoverse.palaeoverse.org/articles/structure-and-standards.html)
- [x] I have performed a self-review of my code.
- [ ] I have added function documentation.
- [ ] I have provided sufficient examples of implementation.
- [ ] If it is a core feature, I have added thorough tests.

