### PR TITLE
Allow CI workflows to run even if the target branch isn't `main`

### DIFF
--- a/.github/workflows/R-CMD-check-hard.yaml
+++ b/.github/workflows/R-CMD-check-hard.yaml
@@ -22,7 +22,6 @@ on:
       - DESCRIPTION
       - NAMESPACE
   pull_request:
-    branches: [main, master]
     paths:
       - .github/workflows/R-CMD-check-hard.yaml
       - .Rbuildignore

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -15,7 +15,6 @@ on:
       - DESCRIPTION
       - NAMESPACE
   pull_request:
-    branches: [main, master]
     paths:
       - .github/workflows/R-CMD-check.yaml
       - .Rbuildignore

--- a/.github/workflows/check-links.yaml
+++ b/.github/workflows/check-links.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches: main
   pull_request:
-    branches: main
   schedule:
     # Every Monday at 8am
     - cron: "0 8 * * 1"

--- a/.github/workflows/check-spelling.yaml
+++ b/.github/workflows/check-spelling.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [main, master]
   pull_request:
-    branches: [main, master]
 
 jobs:
   check-spelling:

--- a/.github/workflows/format-lint.yaml
+++ b/.github/workflows/format-lint.yaml
@@ -14,7 +14,6 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref }}

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -13,7 +13,6 @@ on:
       - DESCRIPTION
       - NAMESPACE
   pull_request:
-    branches: [main, master]
     paths:
       - .github/workflows/lint.yaml
       - .Rbuildignore

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [main, master]
   pull_request:
-    branches: [main, master]
   release:
     types: [published]
   workflow_dispatch:


### PR DESCRIPTION
As part of the implementation of `cli` and `rlang`, I do a lot of branches upon other branches. Currently, CI workflows only run for the first branch (which  targets `main`) and not for the others because their target branch isn't `main`.

This PR allows CI workflows to run even if the target branch isn't `main`.

## Checklist before requesting a review
- [x] I have read palaeoverse's [standards and structure](https://palaeoverse.palaeoverse.org/articles/structure-and-standards.html)
- [x] I have performed a self-review of my code.
- [ ] I have added function documentation.
- [ ] I have provided sufficient examples of implementation.
- [ ] If it is a core feature, I have added thorough tests.

