### PR TITLE
Remove default value `NULL` from mandatory arguments

### DIFF
--- a/R/phylo_check.R
+++ b/R/phylo_check.R
@@ -73,19 +73,22 @@ phylo_check <- function(
   out = "full_table",
   sort = "presence"
 ) {
-
   #Errors for incorrect input
-  if(missing(tree)) stop("argument \"tree\" is missing, with no default")
+  if (missing(tree)) {
+    stop("argument \"tree\" is missing, with no default")
+  }
 
   if (!inherits(tree, "phylo")) {
     stop("Phylogeny must be a phylo object")
   }
 
+  if (missing(list)) {
+    stop("argument \"list\" is missing, with no default")
+  }
+
   if (!is.vector(list)) {
     stop("List of taxa must be a vector")
   }
-
-  if(missing(list)) stop("argument \"list\" is missing, with no default")
 
   if (any(grepl("[^[:alnum:][:space:]_]", list))) {
     stop(

--- a/R/phylo_check.R
+++ b/R/phylo_check.R
@@ -68,22 +68,15 @@
 #' par(oldpar)
 #' @export
 phylo_check <- function(
-  tree = NULL,
-  list = NULL,
+  tree,
+  list,
   out = "full_table",
   sort = "presence"
 ) {
   #Errors for incorrect input
-  if (is.null(tree)) {
-    stop("Phylogeny must be provided")
-  }
 
   if (!inherits(tree, "phylo")) {
     stop("Phylogeny must be a phylo object")
-  }
-
-  if (is.null(list)) {
-    stop("List of taxa to check against must be provided")
   }
 
   if (!is.vector(list)) {

--- a/R/phylo_check.R
+++ b/R/phylo_check.R
@@ -73,7 +73,9 @@ phylo_check <- function(
   out = "full_table",
   sort = "presence"
 ) {
+
   #Errors for incorrect input
+  if(missing(tree)) stop("argument \"tree\" is missing, with no default")
 
   if (!inherits(tree, "phylo")) {
     stop("Phylogeny must be a phylo object")
@@ -82,6 +84,8 @@ phylo_check <- function(
   if (!is.vector(list)) {
     stop("List of taxa must be a vector")
   }
+
+  if(missing(list)) stop("argument \"list\" is missing, with no default")
 
   if (any(grepl("[^[:alnum:][:space:]_]", list))) {
     stop(

--- a/R/phylo_check.R
+++ b/R/phylo_check.R
@@ -74,16 +74,8 @@ phylo_check <- function(
   sort = "presence"
 ) {
   #Errors for incorrect input
-  if (missing(tree)) {
-    stop("argument \"tree\" is missing, with no default")
-  }
-
   if (!inherits(tree, "phylo")) {
     stop("Phylogeny must be a phylo object")
-  }
-
-  if (missing(list)) {
-    stop("argument \"list\" is missing, with no default")
   }
 
   if (!is.vector(list)) {

--- a/R/tax_certainty.R
+++ b/R/tax_certainty.R
@@ -104,14 +104,6 @@ tax_certainty <- function(
 ) {
   # Error handling
 
-  if (missing(taxdf)) {
-    stop("argument \"taxdf\" is missing, with no default")
-  }
-
-  if (missing(name)) {
-    stop("argument \"name\" is missing, with no default")
-  }
-
   # Check taxdf is dataframe
   if (!is.data.frame(taxdf)) {
     stop("`taxdf` must be a data.frame.")

--- a/R/tax_certainty.R
+++ b/R/tax_certainty.R
@@ -96,13 +96,22 @@
 #'                            append = FALSE)
 #' @export
 tax_certainty <- function(
-  taxdf = NULL,
-  name = NULL,
+  taxdf,
+  name,
   terms = NULL,
   certainty = c(1, 0),
   append = TRUE
 ) {
   # Error handling
+
+  if (missing(taxdf)) {
+    stop("argument \"taxdf\" is missing, with no default")
+  }
+
+  if (missing(name)) {
+    stop("argument \"name\" is missing, with no default")
+  }
+
   # Check taxdf is dataframe
   if (!is.data.frame(taxdf)) {
     stop("`taxdf` must be a data.frame.")

--- a/R/tax_unique.R
+++ b/R/tax_unique.R
@@ -142,10 +142,6 @@ tax_unique <- function(
   append = FALSE
 ) {
   #Give errors for incorrect input
-  if (missing(occdf)) {
-    stop("Must enter an `occdf` of occurrences or taxon names")
-  }
-
   if (!is.data.frame(occdf)) {
     stop("`occdf` must be a data.frame")
   }

--- a/R/tax_unique.R
+++ b/R/tax_unique.R
@@ -132,7 +132,7 @@
 #' @export
 #'
 tax_unique <- function(
-  occdf = NULL,
+  occdf,
   binomial = NULL,
   species = NULL,
   genus = NULL,
@@ -142,7 +142,7 @@ tax_unique <- function(
   append = FALSE
 ) {
   #Give errors for incorrect input
-  if (is.null(occdf)) {
+  if (missing(occdf)) {
     stop("Must enter an `occdf` of occurrences or taxon names")
   }
 

--- a/man/phylo_check.Rd
+++ b/man/phylo_check.Rd
@@ -4,7 +4,7 @@
 \alias{phylo_check}
 \title{Check phylogeny tip names}
 \usage{
-phylo_check(tree = NULL, list = NULL, out = "full_table", sort = "presence")
+phylo_check(tree, list, out = "full_table", sort = "presence")
 }
 \arguments{
 \item{tree}{\code{phylo}. A phylo object containing the phylogeny.}

--- a/man/tax_certainty.Rd
+++ b/man/tax_certainty.Rd
@@ -4,13 +4,7 @@
 \alias{tax_certainty}
 \title{Classify the certainty of taxonomic identifications}
 \usage{
-tax_certainty(
-  taxdf = NULL,
-  name = NULL,
-  terms = NULL,
-  certainty = c(1, 0),
-  append = TRUE
-)
+tax_certainty(taxdf, name, terms = NULL, certainty = c(1, 0), append = TRUE)
 }
 \arguments{
 \item{taxdf}{\code{data.frame}. A \code{data.frame} with a named column

--- a/man/tax_unique.Rd
+++ b/man/tax_unique.Rd
@@ -5,7 +5,7 @@
 \title{Filter occurrences to unique taxa}
 \usage{
 tax_unique(
-  occdf = NULL,
+  occdf,
   binomial = NULL,
   species = NULL,
   genus = NULL,

--- a/tests/testthat/_snaps/phylo_check.md
+++ b/tests/testthat/_snaps/phylo_check.md
@@ -4,7 +4,7 @@
       phylo_check()
     Condition
       Error in `phylo_check()`:
-      ! Phylogeny must be provided
+      ! argument "tree" is missing, with no default
 
 ---
 
@@ -45,7 +45,7 @@
       phylo_check(tree)
     Condition
       Error in `phylo_check()`:
-      ! List of taxa to check against must be provided
+      ! argument "list" is missing, with no default
 
 # arg 'out' works
 

--- a/tests/testthat/_snaps/phylo_check.md
+++ b/tests/testthat/_snaps/phylo_check.md
@@ -1,10 +1,10 @@
 # basic behavior works
 
     Code
-      phylo_check()
+      phylo_check(data.frame())
     Condition
       Error in `phylo_check()`:
-      ! argument "tree" is missing, with no default
+      ! Phylogeny must be a phylo object
 
 ---
 
@@ -17,7 +17,7 @@
 ---
 
     Code
-      phylo_check(data.frame())
+      phylo_check(NA)
     Condition
       Error in `phylo_check()`:
       ! Phylogeny must be a phylo object
@@ -25,10 +25,10 @@
 ---
 
     Code
-      phylo_check(NA)
+      phylo_check()
     Condition
       Error in `phylo_check()`:
-      ! Phylogeny must be a phylo object
+      ! argument "tree" is missing, with no default
 
 # arg 'list' works
 

--- a/tests/testthat/_snaps/tax_certainty.md
+++ b/tests/testthat/_snaps/tax_certainty.md
@@ -1,3 +1,19 @@
+# throws error for missing required arguments
+
+    Code
+      tax_certainty()
+    Condition
+      Error in `tax_certainty()`:
+      ! argument "taxdf" is missing, with no default
+
+---
+
+    Code
+      tax_certainty(taxdf = occdf)
+    Condition
+      Error in `tax_certainty()`:
+      ! argument "name" is missing, with no default
+
 # tax_certainty() basic behavior
 
     Code

--- a/tests/testthat/_snaps/tax_certainty.md
+++ b/tests/testthat/_snaps/tax_certainty.md
@@ -1,6 +1,14 @@
 # throws error for missing required arguments
 
     Code
+      tax_certainty(taxdf = 1, name = "foo")
+    Condition
+      Error in `tax_certainty()`:
+      ! `taxdf` must be a data.frame.
+
+---
+
+    Code
       tax_certainty()
     Condition
       Error in `tax_certainty()`:
@@ -13,14 +21,6 @@
     Condition
       Error in `tax_certainty()`:
       ! argument "name" is missing, with no default
-
----
-
-    Code
-      tax_certainty(taxdf = 1, name = "foo")
-    Condition
-      Error in `tax_certainty()`:
-      ! `taxdf` must be a data.frame.
 
 # tax_certainty() basic behavior
 

--- a/tests/testthat/_snaps/tax_certainty.md
+++ b/tests/testthat/_snaps/tax_certainty.md
@@ -9,7 +9,7 @@
 ---
 
     Code
-      tax_certainty(taxdf = occdf)
+      tax_certainty(taxdf = tetrapods)
     Condition
       Error in `tax_certainty()`:
       ! argument "name" is missing, with no default

--- a/tests/testthat/_snaps/tax_certainty.md
+++ b/tests/testthat/_snaps/tax_certainty.md
@@ -14,6 +14,14 @@
       Error in `tax_certainty()`:
       ! argument "name" is missing, with no default
 
+---
+
+    Code
+      tax_certainty(taxdf = 1, name = "foo")
+    Condition
+      Error in `tax_certainty()`:
+      ! `taxdf` must be a data.frame.
+
 # tax_certainty() basic behavior
 
     Code

--- a/tests/testthat/_snaps/tax_unique.md
+++ b/tests/testthat/_snaps/tax_unique.md
@@ -1,10 +1,22 @@
 # basic behaviour works
 
     Code
-      tax_unique()
+      tax_unique(data.frame(genus = "Tyrannosaurus", binomial = "Tyrannosaurus rex",
+        family = "Tyrannosauridae", order = "Coelurosauria", class = "Tetanurae"),
+      species = "species", genus = "genus")
     Condition
       Error in `tax_unique()`:
-      ! Must enter an `occdf` of occurrences or taxon names
+      ! `occdf` does not contain column name provided to `species`
+
+---
+
+    Code
+      tax_unique(data.frame(species = "Tyrannosaurus", binomial = "Tyrannosaurus rex",
+        family = "Tyrannosauridae", order = "Coelurosauria", class = "Tetanurae"),
+      species = "species", genus = "genus")
+    Condition
+      Error in `tax_unique()`:
+      ! `occdf` does not contain column name provided to `genus`
 
 ---
 
@@ -33,22 +45,10 @@
 ---
 
     Code
-      tax_unique(data.frame(genus = "Tyrannosaurus", binomial = "Tyrannosaurus rex",
-        family = "Tyrannosauridae", order = "Coelurosauria", class = "Tetanurae"),
-      species = "species", genus = "genus")
+      tax_unique()
     Condition
       Error in `tax_unique()`:
-      ! `occdf` does not contain column name provided to `species`
-
----
-
-    Code
-      tax_unique(data.frame(species = "Tyrannosaurus", binomial = "Tyrannosaurus rex",
-        family = "Tyrannosauridae", order = "Coelurosauria", class = "Tetanurae"),
-      species = "species", genus = "genus")
-    Condition
-      Error in `tax_unique()`:
-      ! `occdf` does not contain column name provided to `genus`
+      ! argument "occdf" is missing, with no default
 
 # tax_unique() cannot use the same column for multiple arguments
 

--- a/tests/testthat/test-phylo_check.R
+++ b/tests/testthat/test-phylo_check.R
@@ -22,10 +22,11 @@ test_that("basic behavior works", {
   expect_true(unique(out[out$taxon_name %in% list, "present_in_list"]))
 
   # input checks
-  expect_snapshot(phylo_check(), error = TRUE)
-  expect_snapshot(phylo_check(1), error = TRUE)
   expect_snapshot(phylo_check(data.frame()), error = TRUE)
+  expect_snapshot(phylo_check(1), error = TRUE)
   expect_snapshot(phylo_check(NA), error = TRUE)
+  skip_if(getRversion() < "4.3.0")
+  expect_snapshot(phylo_check(), error = TRUE)
 })
 
 test_that("arg 'list' works", {
@@ -40,9 +41,6 @@ test_that("arg 'list' works", {
 
   # doesn't accept punctuation
   expect_snapshot(phylo_check(tree, c("foo.bar")), error = TRUE)
-
-  # input checks
-  expect_snapshot(phylo_check(tree), error = TRUE)
 
   # TODO: all those cases should error, docs say it should be a character vector
   # expect_snapshot(phylo_check(tree, list = 1), error = TRUE)
@@ -61,6 +59,10 @@ test_that("arg 'list' works", {
       row.names = 38:39
     )
   )
+
+  # input checks
+  skip_if(getRversion() < "4.3.0")
+  expect_snapshot(phylo_check(tree), error = TRUE)
 })
 
 test_that("arg 'out' works", {
@@ -111,7 +113,7 @@ test_that("arg 'out' works", {
     list(
       edge = matrix(
         c(
-          8L, 9L, 10L, 11L, 11L, 10L, 12L, 12L, 9L, 8L, 13L, 13L, 9L, 10L, 11L, 
+          8L, 9L, 10L, 11L, 11L, 10L, 12L, 12L, 9L, 8L, 13L, 13L, 9L, 10L, 11L,
           1L, 2L, 12L, 3L, 4L, 5L, 13L, 6L, 7L
         ),
         nrow = 12L,

--- a/tests/testthat/test-tax_certainty.R
+++ b/tests/testthat/test-tax_certainty.R
@@ -1,8 +1,6 @@
 test_that("throws error for missing required arguments", {
   expect_snapshot(tax_certainty(), error = TRUE)
-  data("tetrapods")
-  occdf <- tetrapods[1:5, ]
-  expect_snapshot(tax_certainty(taxdf = occdf), error = TRUE)
+  expect_snapshot(tax_certainty(taxdf = tetrapods), error = TRUE)
   expect_snapshot(tax_certainty(taxdf = 1, name = "foo"), error = TRUE)
 })
 

--- a/tests/testthat/test-tax_certainty.R
+++ b/tests/testthat/test-tax_certainty.R
@@ -1,3 +1,11 @@
+test_that("throws error for missing required arguments", {
+  expect_snapshot(tax_certainty(), error = TRUE)
+  data("tetrapods")
+  occdf <- tetrapods[1:5, ]
+  expect_snapshot(tax_certainty(taxdf = occdf), error = TRUE)
+  expect_snapshot(tax_certainty(taxdf = 1, name = "foo"), error = TRUE)
+})
+
 test_that("tax_certainty() basic behavior", {
   data("tetrapods")
   occdf <- tetrapods[1:5, ]

--- a/tests/testthat/test-tax_certainty.R
+++ b/tests/testthat/test-tax_certainty.R
@@ -1,7 +1,8 @@
 test_that("throws error for missing required arguments", {
+  expect_snapshot(tax_certainty(taxdf = 1, name = "foo"), error = TRUE)
+  skip_if(getRversion() < "4.3.0")
   expect_snapshot(tax_certainty(), error = TRUE)
   expect_snapshot(tax_certainty(taxdf = tetrapods), error = TRUE)
-  expect_snapshot(tax_certainty(taxdf = 1, name = "foo"), error = TRUE)
 })
 
 test_that("tax_certainty() basic behavior", {

--- a/tests/testthat/test-tax_unique.R
+++ b/tests/testthat/test-tax_unique.R
@@ -33,12 +33,6 @@ test_that("basic behaviour works", {
     )
   )
 
-  # input checks
-  expect_snapshot(tax_unique(), error = TRUE)
-  expect_snapshot(tax_unique(data.frame()), error = TRUE)
-  expect_snapshot(tax_unique(100), error = TRUE)
-  expect_snapshot(tax_unique(NA), error = TRUE)
-
   # must have columns genus and species
   expect_snapshot(
     tax_unique(
@@ -68,6 +62,13 @@ test_that("basic behaviour works", {
     ),
     error = TRUE
   )
+
+  # input checks
+  expect_snapshot(tax_unique(data.frame()), error = TRUE)
+  expect_snapshot(tax_unique(100), error = TRUE)
+  expect_snapshot(tax_unique(NA), error = TRUE)
+  skip_if(getRversion() < "4.3.0")
+  expect_snapshot(tax_unique(), error = TRUE)
 })
 
 test_that("tax_unique() cannot use the same column for multiple arguments", {


### PR DESCRIPTION
## Removes default value NULL from required arguments

Solves #296 by removing NULL as default value for required arguments in `phylo_check`, `tax_certainty`, and `tax_unique`.

## Motivation and Context

See #296 

## Checklist before requesting a review
- [x] I have read palaeoverse's [standards and structure](https://palaeoverse.palaeoverse.org/articles/structure-and-standards.html)
- [x] I have performed a self-review of my code.
- [x] I have added function documentation.
- [x] I have provided sufficient examples of implementation.
- [x] If it is a core feature, I have added thorough tests.

