### PR TITLE
Change default value of `round` in `axis_geo()` to `NULL`

### DIFF
--- a/R/axis_geo.R
+++ b/R/axis_geo.R
@@ -825,11 +825,12 @@ axis_geo <- function(
     if (phylo) {
       tick_at <- (tick_at - phylo_alpha) / phylo_beta
     }
-    if (is.numeric(round)) {
-      tick_labels <- round(tick_at, digits = round)
-    } else {
+    if (is.null(round)){
       tick_labels <- as.character(tick_at) # removes trailing zeros
+    } else {
+      tick_labels <- round(tick_at, digits = round)
     }
+
   }
   if (phylo) {
     if (is.null(tick_at)) {

--- a/R/axis_geo.R
+++ b/R/axis_geo.R
@@ -129,10 +129,10 @@
 #'   marks and numeric tick labels placed at the interval boundaries. If
 #'   \code{TRUE}, this overrides \code{tick_at} and \code{tick_labels}.
 #' @param round \code{integer}. Number of decimal places to which exact axis
-#'   labels should be rounded (using \code{\link[base]{round}}). If no value is
-#'   specified, the exact values will be used. Trailing zeros are always
-#'   removed. \code{tick_at} and \code{tick_labels} can be used to include
-#'   labels with trailing zeros.
+#'   labels should be rounded (using \code{\link[base]{round}}). If no numeric
+#'   value is specified, the exact values will be used. Trailing zeros are
+#'   always removed. \code{tick_at} and \code{tick_labels} can be used to
+#'   include labels with trailing zeros.
 #' @param tick_at A \code{numeric} vector specifying custom points at which tick
 #'   marks are to be drawn on the axis. If specified, this is passed directly to
 #'   \code{\link[graphics]{axis}}. If \code{phylo} is \code{TRUE}, these values
@@ -248,7 +248,7 @@ axis_geo <- function(
   bkgd = "grey90",
   neg = FALSE,
   exact = FALSE,
-  round = FALSE,
+  round = NULL,
   # passed to axis():
   tick_at = NULL,
   tick_labels = TRUE,
@@ -826,7 +826,7 @@ axis_geo <- function(
       tick_at <- (tick_at - phylo_alpha) / phylo_beta
     }
     if (is.numeric(round)) {
-      tick_labels <- round(tick_at, round)
+      tick_labels <- round(tick_at, digits = round)
     } else {
       tick_labels <- as.character(tick_at) # removes trailing zeros
     }

--- a/R/axis_geo.R
+++ b/R/axis_geo.R
@@ -825,12 +825,11 @@ axis_geo <- function(
     if (phylo) {
       tick_at <- (tick_at - phylo_alpha) / phylo_beta
     }
-    if (is.null(round)){
+    if (is.null(round)) {
       tick_labels <- as.character(tick_at) # removes trailing zeros
     } else {
       tick_labels <- round(tick_at, digits = round)
     }
-
   }
   if (phylo) {
     if (is.null(tick_at)) {

--- a/man/axis_geo.Rd
+++ b/man/axis_geo.Rd
@@ -24,7 +24,7 @@ axis_geo(
   bkgd = "grey90",
   neg = FALSE,
   exact = FALSE,
-  round = FALSE,
+  round = NULL,
   tick_at = NULL,
   tick_labels = TRUE,
   title = NULL,
@@ -116,10 +116,10 @@ marks and numeric tick labels placed at the interval boundaries. If
 \code{TRUE}, this overrides \code{tick_at} and \code{tick_labels}.}
 
 \item{round}{\code{integer}. Number of decimal places to which exact axis
-labels should be rounded (using \code{\link[base]{round}}). If no value is
-specified, the exact values will be used. Trailing zeros are always
-removed. \code{tick_at} and \code{tick_labels} can be used to include
-labels with trailing zeros.}
+labels should be rounded (using \code{\link[base]{round}}). If no numeric
+value is specified, the exact values will be used. Trailing zeros are
+always removed. \code{tick_at} and \code{tick_labels} can be used to
+include labels with trailing zeros.}
 
 \item{tick_at}{A \code{numeric} vector specifying custom points at which tick
 marks are to be drawn on the axis. If specified, this is passed directly to


### PR DESCRIPTION
## Description

The `round` argument of `axis_geo` previously was set to a logical value. It is now changed to `NULL` and the description states clearly that the expected input is a numeric value.

## Motivation and Context

This keeps Booleans for strictly logical inputs, and NULL as (yet unspecified) default value.

## Checklist before requesting a review
- [x] I have read palaeoverse's [standards and structure](https://palaeoverse.palaeoverse.org/articles/structure-and-standards.html)
- [x] I have performed a self-review of my code.
- [x] I have updated function documentation.
- [ ] I have provided sufficient examples of implementation.
- [ ] If it is a core feature, I have added thorough tests.

