### PR TITLE
`tax_unique()` should accept underscores in "binomial" or "name" column 

### DIFF
--- a/R/tax_unique.R
+++ b/R/tax_unique.R
@@ -226,7 +226,7 @@ tax_unique <- function(
   }
 
   if (
-    !is.null(binomial) && any(grepl("[^[:alnum:][:space:]]", occdf[[binomial]]))
+    !is.null(binomial) && any(grepl("[^[:alnum:][:space:]_]", occdf[[binomial]]))
   ) {
     stop(
       "`binomial` column should not contain punctuation except spaces or
@@ -234,7 +234,7 @@ tax_unique <- function(
     )
   }
 
-  if (!is.null(name) && any(grepl("[^[:alnum:][:space:]]", occdf[[name]]))) {
+  if (!is.null(name) && any(grepl("[^[:alnum:][:space:]_]", occdf[[name]]))) {
     stop(
       "`name` column should not contain punctuation except spaces or
          underscores"

--- a/R/tax_unique.R
+++ b/R/tax_unique.R
@@ -226,7 +226,8 @@ tax_unique <- function(
   }
 
   if (
-    !is.null(binomial) && any(grepl("[^[:alnum:][:space:]_]", occdf[[binomial]]))
+    !is.null(binomial) &&
+      any(grepl("[^[:alnum:][:space:]_]", occdf[[binomial]]))
   ) {
     stop(
       "`binomial` column should not contain punctuation except spaces or

--- a/tests/testthat/test-tax_unique.R
+++ b/tests/testthat/test-tax_unique.R
@@ -459,7 +459,7 @@ test_that("taxonomic columns must not contain punctuation", {
   )
 })
 
-test_that("underscores in binomial or name column work",{
+test_that("underscores in binomial or name column work", {
   dat <- data.frame(
     species = "rex",
     genus = "Tyrannosaurus",
@@ -494,5 +494,4 @@ test_that("underscores in binomial or name column work",{
     class = "class",
     name = "name"
   ))
-
 })

--- a/tests/testthat/test-tax_unique.R
+++ b/tests/testthat/test-tax_unique.R
@@ -458,3 +458,41 @@ test_that("taxonomic columns must not contain punctuation", {
     error = TRUE
   )
 })
+
+test_that("underscores in binomial or name column work",{
+  dat <- data.frame(
+    species = "rex",
+    genus = "Tyrannosaurus",
+    binomial = "Tyrannosaurus_rex",
+    family = "Tyrannosauridae",
+    order = "Coelurosauria",
+    class = "Tetanurae"
+  )
+  expect_no_error(tax_unique(
+    occdf = dat,
+    binomial = "binomial",
+    family = "family",
+    order = "order",
+    class = "class"
+  ))
+
+  dat <- data.frame(
+    name = "foo_bar",
+    species = "rex",
+    genus = "Tyrannosaurus",
+    binomial = "Tyrannosaurus rex",
+    family = "Tyrannosauridae",
+    order = "Coelurosauria",
+    class = "Tetanurae"
+  )
+
+  expect_no_error(tax_unique(
+    occdf = dat,
+    binomial = "binomial",
+    family = "family",
+    order = "order",
+    class = "class",
+    name = "name"
+  ))
+
+})


### PR DESCRIPTION
## Description

See #256 : `tax_unique()` throws an error when underscores are used in the `binomial` or `name` argument. 

## Motivation and Context

I transformed #256 into two failing tests to track progress and fixed the regexes. Unfortunately this surfaced another error & warning:

```
Error in if (is.na(to_retain$unique_name[i])) { : 
  argument is of length zero
In addition: Warning message:
In merge.data.frame(subset(occurrences, subset = !is.na(genus),  :
  column name ‘genus_species.y’ is duplicated in the result
```

Haven't found the cause of this so far, but will keep looking.

## Checklist before requesting a review
- [ ] I have read palaeoverse's [standards and structure](https://palaeoverse.palaeoverse.org/articles/structure-and-standards.html)
- [ ] I have performed a self-review of my code.
- [ ] I have added function documentation.
- [ ] I have provided sufficient examples of implementation.
- [ ] If it is a core feature, I have added thorough tests.

