### PR TITLE
Check that args are named in `time_bins()`

### DIFF
--- a/R/time_bins.R
+++ b/R/time_bins.R
@@ -123,6 +123,8 @@ time_bins <- function(
   scale = "GTS2020",
   plot = FALSE
 ) {
+  ensure_args_are_named()
+
   # Error handling -------------------------------------------------------
   if (
     !is.character(interval) &&

--- a/tests/testthat/_snaps/time_bins.md
+++ b/tests/testthat/_snaps/time_bins.md
@@ -1,3 +1,39 @@
+# time_bins errors with unnamed args
+
+    Code
+      time_bins("Maastrichtian", "stage")
+    Condition
+      Error in `time_bins()`:
+      ! All arguments must be named.
+      i Currently, there are 2 arguments that should be named.
+
+---
+
+    Code
+      time_bins(interval = "Maastrichtian", "stage")
+    Condition
+      Error in `time_bins()`:
+      ! All arguments must be named.
+      i Currently, there is 1 argument that should be named.
+
+---
+
+    Code
+      time_bins("Maastrichtian", "stage", 10)
+    Condition
+      Error in `time_bins()`:
+      ! All arguments must be named.
+      i Currently, there are 3 arguments that should be named.
+
+---
+
+    Code
+      time_bins("Maastrichtian", "stage", size = 10)
+    Condition
+      Error in `time_bins()`:
+      ! All arguments must be named.
+      i Currently, there are 2 arguments that should be named.
+
 # arg 'interval' works
 
     Code

--- a/tests/testthat/test-time_bins.R
+++ b/tests/testthat/test-time_bins.R
@@ -20,6 +20,13 @@ test_that("time_bins() default behaviour", {
   )
 })
 
+test_that("time_bins errors with unnamed args", {
+  expect_snapshot(time_bins("Maastrichtian", "stage"), error = TRUE)
+  expect_snapshot(time_bins(interval = "Maastrichtian", "stage"), error = TRUE)
+  expect_snapshot(time_bins("Maastrichtian", "stage", 10), error = TRUE)
+  expect_snapshot(time_bins("Maastrichtian", "stage", size = 10), error = TRUE)
+})
+
 test_that("arg 'interval' works", {
   expect_equal(
     time_bins(interval = "Maastrichtian"),


### PR DESCRIPTION
This PR and subsequent ones that implement `ensure_args_are_named()` are co-authored by Claude Opus 5.

Part of #216 

## Checklist before requesting a review
- [x] I have read palaeoverse's [standards and structure](https://palaeoverse.palaeoverse.org/articles/structure-and-standards.html)
- [x] I have performed a self-review of my code.
- [ ] I have added function documentation.
- [ ] I have provided sufficient examples of implementation.
- [ ] If it is a core feature, I have added thorough tests.


