### PR TITLE
Check that args are named in `palaeorotate()`

### DIFF
--- a/R/palaeorotate.R
+++ b/R/palaeorotate.R
@@ -177,6 +177,8 @@ palaeorotate <- function(
   uncertainty = TRUE,
   round = 3
 ) {
+  ensure_args_are_named()
+
   # Error-handling ----------------------------------------------------------
   if (!exists("occdf") || !is.data.frame(occdf)) {
     stop("Please supply `occdf` as a data.frame.")

--- a/R/palaeorotate.R
+++ b/R/palaeorotate.R
@@ -177,7 +177,7 @@ palaeorotate <- function(
   uncertainty = TRUE,
   round = 3
 ) {
-  ensure_args_are_named()
+  ensure_args_are_named(exceptions = "occdf")
 
   # Error-handling ----------------------------------------------------------
   if (!exists("occdf") || !is.data.frame(occdf)) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,11 +1,14 @@
 #' Check whether there are unnamed arguments that should be named.
 #'
-#' This errors if some arguments are unnamed or if their names are partially
-#' matched.
+#' This errors if some arguments (apart from `exceptions`) are unnamed or
+#' if their names are partially matched.
+#'
+#' @param exceptions Arguments that can be unnamed.
 #'
 #' @noRd
-ensure_args_are_named <- function() {
+ensure_args_are_named <- function(exceptions = NULL) {
   args_in_call_from_user <- rlang::call_args_names(rlang::caller_call())
+  unnamed_exceptions <- setdiff(exceptions, args_in_call_from_user)
   unnamed_args <- args_in_call_from_user[which(args_in_call_from_user == "")]
   named_args <- args_in_call_from_user[which(
     !is.null(args_in_call_from_user) & args_in_call_from_user != ""
@@ -23,11 +26,18 @@ ensure_args_are_named <- function() {
     )
   }
 
-  if (length(unnamed_args) > 0) {
+  if (length(unnamed_args) > length(unnamed_exceptions)) {
+    extra <- if (length(exceptions) > 0) {
+      " (except for {.val {cli::cli_vec(exceptions)}})"
+    } else {
+      ""
+    }
+    msg <- paste0("All arguments must be named", extra, ".")
+    n <- length(unnamed_args) - length(unnamed_exceptions)
     cli::cli_abort(
       c(
-        "All arguments must be named.",
-        "i" = "Currently, there {?is/are} {length(unnamed_args)} argument{?s} that should be named."
+        msg,
+        "i" = "Currently, there {?is/are} {n} argument{?s} that should be named."
       ),
       call = rlang::caller_env()
     )

--- a/tests/testthat/_snaps/palaeorotate.md
+++ b/tests/testthat/_snaps/palaeorotate.md
@@ -22,6 +22,42 @@
       Error in `palaeorotate()`:
       ! Defined `lng`, `lat`, or `age` not found in `occdf`.
 
+# palaeorotate errors with unnamed args
+
+    Code
+      palaeorotate(occdf, "lng")
+    Condition
+      Error in `palaeorotate()`:
+      ! All arguments must be named.
+      i Currently, there are 2 arguments that should be named.
+
+---
+
+    Code
+      palaeorotate(occdf = occdf, "lng")
+    Condition
+      Error in `palaeorotate()`:
+      ! All arguments must be named.
+      i Currently, there is 1 argument that should be named.
+
+---
+
+    Code
+      palaeorotate(occdf, "lng", "lat")
+    Condition
+      Error in `palaeorotate()`:
+      ! All arguments must be named.
+      i Currently, there are 3 arguments that should be named.
+
+---
+
+    Code
+      palaeorotate(occdf, "lng", lat = "lat")
+    Condition
+      Error in `palaeorotate()`:
+      ! All arguments must be named.
+      i Currently, there are 2 arguments that should be named.
+
 # input checks for longitude
 
     Code

--- a/tests/testthat/_snaps/palaeorotate.md
+++ b/tests/testthat/_snaps/palaeorotate.md
@@ -28,8 +28,8 @@
       palaeorotate(occdf, "lng")
     Condition
       Error in `palaeorotate()`:
-      ! All arguments must be named.
-      i Currently, there are 2 arguments that should be named.
+      ! All arguments must be named (except for "occdf").
+      i Currently, there is 1 argument that should be named.
 
 ---
 
@@ -37,7 +37,7 @@
       palaeorotate(occdf = occdf, "lng")
     Condition
       Error in `palaeorotate()`:
-      ! All arguments must be named.
+      ! All arguments must be named (except for "occdf").
       i Currently, there is 1 argument that should be named.
 
 ---
@@ -46,8 +46,8 @@
       palaeorotate(occdf, "lng", "lat")
     Condition
       Error in `palaeorotate()`:
-      ! All arguments must be named.
-      i Currently, there are 3 arguments that should be named.
+      ! All arguments must be named (except for "occdf").
+      i Currently, there are 2 arguments that should be named.
 
 ---
 
@@ -55,8 +55,8 @@
       palaeorotate(occdf, "lng", lat = "lat")
     Condition
       Error in `palaeorotate()`:
-      ! All arguments must be named.
-      i Currently, there are 2 arguments that should be named.
+      ! All arguments must be named (except for "occdf").
+      i Currently, there is 1 argument that should be named.
 
 # input checks for longitude
 

--- a/tests/testthat/test-palaeorotate.R
+++ b/tests/testthat/test-palaeorotate.R
@@ -23,6 +23,14 @@ test_that("arg 'occdf' works", {
   )
 })
 
+test_that("palaeorotate errors with unnamed args", {
+  occdf <- data.frame(lng = c(2, -103), lat = c(46, 35), age = c(88, 125))
+  expect_snapshot(palaeorotate(occdf, "lng"), error = TRUE)
+  expect_snapshot(palaeorotate(occdf = occdf, "lng"), error = TRUE)
+  expect_snapshot(palaeorotate(occdf, "lng", "lat"), error = TRUE)
+  expect_snapshot(palaeorotate(occdf, "lng", lat = "lat"), error = TRUE)
+})
+
 test_that("Large occdf inputs are chunked before being sent to the API", {
   skip_if_offline(host = "gws.gplates.org")
   skip_if_not_installed("vcr")

--- a/tests/testthat/test-palaeorotate.R
+++ b/tests/testthat/test-palaeorotate.R
@@ -23,6 +23,26 @@ test_that("arg 'occdf' works", {
   )
 })
 
+test_that("piping and not piping the first argument give the same result", {
+  skip_if_offline(host = "gws.gplates.org")
+  skip_if_not_installed("vcr")
+
+  occdf <- data.frame(
+    lng = c(2, -103, -66),
+    lat = c(46, 35, -7),
+    age = c(88, 125, 300)
+  )
+
+  vcr::use_cassette("palaeorotate-paleomap", {
+    piped <- occdf |> palaeorotate(model = "PALEOMAP")
+  })
+  vcr::use_cassette("palaeorotate-paleomap", {
+    not_piped <- palaeorotate(occdf, model = "PALEOMAP")
+  })
+
+  expect_equal(piped, not_piped)
+})
+
 test_that("palaeorotate errors with unnamed args", {
   occdf <- data.frame(lng = c(2, -103), lat = c(46, 35), age = c(88, 125))
   expect_snapshot(palaeorotate(occdf, "lng"), error = TRUE)


### PR DESCRIPTION
This PR and subsequent ones that implement `ensure_args_are_named()` are co-authored by Claude Opus 5.

Part of #216 

## Checklist before requesting a review
- [x] I have read palaeoverse's [standards and structure](https://palaeoverse.palaeoverse.org/articles/structure-and-standards.html)
- [x] I have performed a self-review of my code.
- [ ] I have added function documentation.
- [ ] I have provided sufficient examples of implementation.
- [ ] If it is a core feature, I have added thorough tests.