### PR TITLE
Check that args are named in `tax_check()`

### DIFF
--- a/R/tax_check.R
+++ b/R/tax_check.R
@@ -90,6 +90,8 @@ tax_check <- function(
   start = 1,
   verbose = TRUE
 ) {
+  ensure_args_are_named()
+
   # ARGUMENT CHECKS --------------------------------------------------------- #
 
   # taxdf: a data.frame with column names and at least one row

--- a/R/tax_check.R
+++ b/R/tax_check.R
@@ -90,7 +90,7 @@ tax_check <- function(
   start = 1,
   verbose = TRUE
 ) {
-  ensure_args_are_named()
+  ensure_args_are_named(exceptions = "taxdf")
 
   # ARGUMENT CHECKS --------------------------------------------------------- #
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,11 +1,14 @@
 #' Check whether there are unnamed arguments that should be named.
 #'
-#' This errors if some arguments are unnamed or if their names are partially
-#' matched.
+#' This errors if some arguments (apart from `exceptions`) are unnamed or
+#' if their names are partially matched.
+#'
+#' @param exceptions Arguments that can be unnamed.
 #'
 #' @noRd
-ensure_args_are_named <- function() {
+ensure_args_are_named <- function(exceptions = NULL) {
   args_in_call_from_user <- rlang::call_args_names(rlang::caller_call())
+  unnamed_exceptions <- setdiff(exceptions, args_in_call_from_user)
   unnamed_args <- args_in_call_from_user[which(args_in_call_from_user == "")]
   named_args <- args_in_call_from_user[which(
     !is.null(args_in_call_from_user) & args_in_call_from_user != ""
@@ -23,11 +26,18 @@ ensure_args_are_named <- function() {
     )
   }
 
-  if (length(unnamed_args) > 0) {
+  if (length(unnamed_args) > length(unnamed_exceptions)) {
+    extra <- if (length(exceptions) > 0) {
+      " (except for {.val {cli::cli_vec(exceptions)}})"
+    } else {
+      ""
+    }
+    msg <- paste0("All arguments must be named", extra, ".")
+    n <- length(unnamed_args) - length(unnamed_exceptions)
     cli::cli_abort(
       c(
-        "All arguments must be named.",
-        "i" = "Currently, there {?is/are} {length(unnamed_args)} argument{?s} that should be named."
+        msg,
+        "i" = "Currently, there {?is/are} {n} argument{?s} that should be named."
       ),
       call = rlang::caller_env()
     )

--- a/tests/testthat/_snaps/tax_check.md
+++ b/tests/testthat/_snaps/tax_check.md
@@ -1,7 +1,7 @@
 # basic behavior works
 
     Code
-      tax_check(data.frame())
+      tax_check(taxdf = data.frame())
     Condition
       Error in `tax_check()`:
       ! Please supply `taxdf` as a data.frame with named columns, containing
@@ -10,16 +10,52 @@
 ---
 
     Code
-      tax_check(1)
+      tax_check(taxdf = 1)
     Condition
       Error in `tax_check()`:
       ! Please supply `taxdf` as a data.frame with named columns, containing
                taxon names, and optionally their higher classification
+
+# tax_check errors with unnamed args
+
+    Code
+      tax_check(dat, "genus")
+    Condition
+      Error in `tax_check()`:
+      ! All arguments must be named.
+      i Currently, there are 2 arguments that should be named.
+
+---
+
+    Code
+      tax_check(taxdf = dat, "genus")
+    Condition
+      Error in `tax_check()`:
+      ! All arguments must be named.
+      i Currently, there is 1 argument that should be named.
+
+---
+
+    Code
+      tax_check(dat, "genus", NULL)
+    Condition
+      Error in `tax_check()`:
+      ! All arguments must be named.
+      i Currently, there are 3 arguments that should be named.
+
+---
+
+    Code
+      tax_check(dat, "genus", group = NULL)
+    Condition
+      Error in `tax_check()`:
+      ! All arguments must be named.
+      i Currently, there are 2 arguments that should be named.
 
 # arg 'name' works
 
     Code
-      tax_check(dat)
+      tax_check(taxdf = dat)
     Condition
       Error in `tax_check()`:
       ! Please specify `name` as a single column name in `taxdf`
@@ -27,7 +63,7 @@
 ---
 
     Code
-      tax_check(dat, name = "nonexistent")
+      tax_check(taxdf = dat, name = "nonexistent")
     Condition
       Error in `tax_check()`:
       ! Please specify `name` as a single column name in `taxdf`
@@ -35,7 +71,7 @@
 ---
 
     Code
-      tax_check(dat, name = 1)
+      tax_check(taxdf = dat, name = 1)
     Condition
       Error in `tax_check()`:
       ! Please specify `name` as a single column name in `taxdf`
@@ -43,7 +79,7 @@
 ---
 
     Code
-      tax_check(dat, name = NULL)
+      tax_check(taxdf = dat, name = NULL)
     Condition
       Error in `tax_check()`:
       ! Please specify `name` as a single column name in `taxdf`
@@ -51,7 +87,7 @@
 ---
 
     Code
-      tax_check(dat, name = character(0))
+      tax_check(taxdf = dat, name = character(0))
     Condition
       Error in `tax_check()`:
       ! Please specify `name` as a single column name in `taxdf`
@@ -59,7 +95,7 @@
 ---
 
     Code
-      tax_check(dat, name = "")
+      tax_check(taxdf = dat, name = "")
     Condition
       Error in `tax_check()`:
       ! Please specify `name` as a single column name in `taxdf`
@@ -67,7 +103,7 @@
 # arg 'group' works
 
     Code
-      tax_check(dat, group = "nonexistent")
+      tax_check(taxdf = dat, group = "nonexistent")
     Condition
       Error in `tax_check()`:
       ! Please specify `group` as a single column name in `taxdf`
@@ -75,7 +111,7 @@
 ---
 
     Code
-      tax_check(dat, group = 1)
+      tax_check(taxdf = dat, group = 1)
     Condition
       Error in `tax_check()`:
       ! Please specify `group` as a single column name in `taxdf`
@@ -83,7 +119,7 @@
 ---
 
     Code
-      tax_check(dat, group = character(0))
+      tax_check(taxdf = dat, group = character(0))
     Condition
       Error in `tax_check()`:
       ! Please specify `group` as a single column name in `taxdf`
@@ -91,7 +127,7 @@
 ---
 
     Code
-      tax_check(dat, group = "")
+      tax_check(taxdf = dat, group = "")
     Condition
       Error in `tax_check()`:
       ! Please specify `group` as a single column name in `taxdf`
@@ -99,7 +135,7 @@
 # arg 'dis' works
 
     Code
-      tax_check(dat, dis = 1)
+      tax_check(taxdf = dat, dis = 1)
     Condition
       Error in `tax_check()`:
       ! `dis` must be a single numeric, greater than 0 and less than 1
@@ -107,7 +143,7 @@
 ---
 
     Code
-      tax_check(dat, dis = 0)
+      tax_check(taxdf = dat, dis = 0)
     Condition
       Error in `tax_check()`:
       ! `dis` must be a single numeric, greater than 0 and less than 1
@@ -115,7 +151,7 @@
 ---
 
     Code
-      tax_check(dat, dis = "a")
+      tax_check(taxdf = dat, dis = "a")
     Condition
       Error in `tax_check()`:
       ! `dis` must be a single numeric, greater than 0 and less than 1
@@ -123,7 +159,7 @@
 ---
 
     Code
-      tax_check(dat, dis = numeric(0))
+      tax_check(taxdf = dat, dis = numeric(0))
     Condition
       Error in `tax_check()`:
       ! `dis` must be a single numeric, greater than 0 and less than 1
@@ -131,7 +167,7 @@
 ---
 
     Code
-      tax_check(dat, dis = NULL)
+      tax_check(taxdf = dat, dis = NULL)
     Condition
       Error in `tax_check()`:
       ! `dis` must be a single numeric, greater than 0 and less than 1
@@ -139,7 +175,7 @@
 # arg 'start' works
 
     Code
-      tax_check(dat, start = -1)
+      tax_check(taxdf = dat, start = -1)
     Condition
       Error in `tax_check()`:
       ! `start` must be a single positive integer, or zero
@@ -147,7 +183,7 @@
 ---
 
     Code
-      tax_check(dat, start = numeric(0))
+      tax_check(taxdf = dat, start = numeric(0))
     Condition
       Error in `tax_check()`:
       ! `start` must be a single positive integer, or zero
@@ -155,7 +191,7 @@
 ---
 
     Code
-      tax_check(dat, start = "a")
+      tax_check(taxdf = dat, start = "a")
     Condition
       Error in `tax_check()`:
       ! `start` must be a single positive integer, or zero
@@ -163,7 +199,7 @@
 # arg 'verbose' works
 
     Code
-      tax_check(dat, verbose = 1)
+      tax_check(taxdf = dat, verbose = 1)
     Condition
       Error in `tax_check()`:
       ! `verbose` must be a single logical value
@@ -171,7 +207,7 @@
 ---
 
     Code
-      tax_check(dat, verbose = numeric(0))
+      tax_check(taxdf = dat, verbose = numeric(0))
     Condition
       Error in `tax_check()`:
       ! `verbose` must be a single logical value
@@ -179,7 +215,7 @@
 ---
 
     Code
-      tax_check(dat, verbose = "a")
+      tax_check(taxdf = dat, verbose = "a")
     Condition
       Error in `tax_check()`:
       ! `verbose` must be a single logical value
@@ -187,7 +223,7 @@
 ---
 
     Code
-      tax_check(dat, verbose = NULL)
+      tax_check(taxdf = dat, verbose = NULL)
     Condition
       Error in `tax_check()`:
       ! `verbose` must be a single logical value

--- a/tests/testthat/_snaps/tax_check.md
+++ b/tests/testthat/_snaps/tax_check.md
@@ -20,7 +20,7 @@
 ---
 
     Code
-      tax_check(taxdf = data.frame())
+      tax_check(data.frame())
     Condition
       Error in `tax_check()`:
       ! Column "genus" not found in `taxdf`.
@@ -28,7 +28,7 @@
 ---
 
     Code
-      tax_check(taxdf = 1)
+      tax_check(1)
     Condition
       Error in `tax_check()`:
       ! `taxdf` must be of class <data.frame>, not the number 1.
@@ -36,7 +36,7 @@
 ---
 
     Code
-      tax_check(taxdf = data.frame(genus = c(NA, "")))
+      tax_check(data.frame(genus = c(NA, "")))
     Condition
       Error in `tax_check()`:
       ! Column "genus" in `taxdf` must have at least one entry that is not NA or empty.
@@ -80,7 +80,7 @@
 # arg 'name' works
 
     Code
-      tax_check(taxdf = dat)
+      tax_check(dat)
     Condition
       Error in `tax_check()`:
       ! Column "genus" not found in `taxdf`.
@@ -88,7 +88,7 @@
 ---
 
     Code
-      tax_check(taxdf = dat, name = "nonexistent")
+      tax_check(dat, name = "nonexistent")
     Condition
       Error in `tax_check()`:
       ! Column "nonexistent" not found in `taxdf`.
@@ -96,7 +96,7 @@
 ---
 
     Code
-      tax_check(taxdf = dat, name = 1)
+      tax_check(dat, name = 1)
     Condition
       Error in `tax_check()`:
       ! `name` must be a single string, not the number 1.
@@ -104,7 +104,7 @@
 ---
 
     Code
-      tax_check(taxdf = dat, name = NULL)
+      tax_check(dat, name = NULL)
     Condition
       Error in `tax_check()`:
       ! `name` must be a single string, not `NULL`.
@@ -112,7 +112,7 @@
 ---
 
     Code
-      tax_check(taxdf = dat, name = character(0))
+      tax_check(dat, name = character(0))
     Condition
       Error in `tax_check()`:
       ! `name` must be a single string, not an empty character vector.
@@ -120,7 +120,7 @@
 ---
 
     Code
-      tax_check(taxdf = dat, name = "")
+      tax_check(dat, name = "")
     Condition
       Error in `tax_check()`:
       ! Column "" not found in `taxdf`.
@@ -147,7 +147,7 @@
 ---
 
     Code
-      tax_check(taxdf = dat, group = "nonexistent")
+      tax_check(dat, group = "nonexistent")
     Condition
       Error in `tax_check()`:
       ! Column "nonexistent" not found in `taxdf`.
@@ -155,7 +155,7 @@
 ---
 
     Code
-      tax_check(taxdf = dat, group = 1)
+      tax_check(dat, group = 1)
     Condition
       Error in `tax_check()`:
       ! `group` must be a single string, not the number 1.
@@ -163,7 +163,7 @@
 ---
 
     Code
-      tax_check(taxdf = dat, group = character(0))
+      tax_check(dat, group = character(0))
     Condition
       Error in `tax_check()`:
       ! `group` must be a single string, not an empty character vector.
@@ -171,7 +171,7 @@
 ---
 
     Code
-      tax_check(taxdf = dat, group = "")
+      tax_check(dat, group = "")
     Condition
       Error in `tax_check()`:
       ! Column "" not found in `taxdf`.
@@ -179,7 +179,7 @@
 # arg 'dis' works
 
     Code
-      tax_check(taxdf = dat, dis = 1)
+      tax_check(dat, dis = 1)
     Condition
       Error in `tax_check()`:
       ! `dis` must be greater than 0 and less than 1.
@@ -187,7 +187,7 @@
 ---
 
     Code
-      tax_check(taxdf = dat, dis = 0)
+      tax_check(dat, dis = 0)
     Condition
       Error in `tax_check()`:
       ! `dis` must be greater than 0 and less than 1.
@@ -195,7 +195,7 @@
 ---
 
     Code
-      tax_check(taxdf = dat, dis = c(0.5, 0.6))
+      tax_check(dat, dis = c(0.5, 0.6))
     Condition
       Error in `tax_check()`:
       ! `dis` must be a number, not a double vector.
@@ -203,7 +203,7 @@
 ---
 
     Code
-      tax_check(taxdf = dat, dis = "a")
+      tax_check(dat, dis = "a")
     Condition
       Error in `tax_check()`:
       ! `dis` must be a number, not the string "a".
@@ -211,7 +211,7 @@
 ---
 
     Code
-      tax_check(taxdf = dat, dis = numeric(0))
+      tax_check(dat, dis = numeric(0))
     Condition
       Error in `tax_check()`:
       ! `dis` must be a number, not an empty numeric vector.
@@ -219,7 +219,7 @@
 ---
 
     Code
-      tax_check(taxdf = dat, dis = NULL)
+      tax_check(dat, dis = NULL)
     Condition
       Error in `tax_check()`:
       ! `dis` must be a number, not `NULL`.
@@ -227,7 +227,7 @@
 # arg 'start' works
 
     Code
-      tax_check(taxdf = dat, start = -1)
+      tax_check(dat, start = -1)
     Condition
       Error in `tax_check()`:
       ! `start` must be a whole number larger than or equal to 0, not the number -1.
@@ -235,7 +235,7 @@
 ---
 
     Code
-      tax_check(taxdf = dat, start = numeric(0))
+      tax_check(dat, start = numeric(0))
     Condition
       Error in `tax_check()`:
       ! `start` must be a whole number, not an empty numeric vector.
@@ -243,7 +243,7 @@
 ---
 
     Code
-      tax_check(taxdf = dat, start = "a")
+      tax_check(dat, start = "a")
     Condition
       Error in `tax_check()`:
       ! `start` must be a whole number, not the string "a".
@@ -251,7 +251,7 @@
 ---
 
     Code
-      tax_check(taxdf = dat, start = NULL)
+      tax_check(dat, start = NULL)
     Condition
       Error in `tax_check()`:
       ! `start` must be a whole number, not `NULL`.
@@ -259,7 +259,7 @@
 # arg 'verbose' works
 
     Code
-      tax_check(taxdf = dat, verbose = 1)
+      tax_check(dat, verbose = 1)
     Condition
       Error in `tax_check()`:
       ! `verbose` must be `TRUE` or `FALSE`, not the number 1.
@@ -267,7 +267,7 @@
 ---
 
     Code
-      tax_check(taxdf = dat, verbose = numeric(0))
+      tax_check(dat, verbose = numeric(0))
     Condition
       Error in `tax_check()`:
       ! `verbose` must be `TRUE` or `FALSE`, not an empty numeric vector.
@@ -275,7 +275,7 @@
 ---
 
     Code
-      tax_check(taxdf = dat, verbose = "a")
+      tax_check(dat, verbose = "a")
     Condition
       Error in `tax_check()`:
       ! `verbose` must be `TRUE` or `FALSE`, not the string "a".
@@ -283,7 +283,7 @@
 ---
 
     Code
-      tax_check(taxdf = dat, verbose = NULL)
+      tax_check(dat, verbose = NULL)
     Condition
       Error in `tax_check()`:
       ! `verbose` must be `TRUE` or `FALSE`, not `NULL`.

--- a/tests/testthat/_snaps/tax_check.md
+++ b/tests/testthat/_snaps/tax_check.md
@@ -22,8 +22,8 @@
       tax_check(dat, "genus")
     Condition
       Error in `tax_check()`:
-      ! All arguments must be named.
-      i Currently, there are 2 arguments that should be named.
+      ! All arguments must be named (except for "taxdf").
+      i Currently, there is 1 argument that should be named.
 
 ---
 
@@ -31,7 +31,7 @@
       tax_check(taxdf = dat, "genus")
     Condition
       Error in `tax_check()`:
-      ! All arguments must be named.
+      ! All arguments must be named (except for "taxdf").
       i Currently, there is 1 argument that should be named.
 
 ---
@@ -40,8 +40,8 @@
       tax_check(dat, "genus", NULL)
     Condition
       Error in `tax_check()`:
-      ! All arguments must be named.
-      i Currently, there are 3 arguments that should be named.
+      ! All arguments must be named (except for "taxdf").
+      i Currently, there are 2 arguments that should be named.
 
 ---
 
@@ -49,8 +49,8 @@
       tax_check(dat, "genus", group = NULL)
     Condition
       Error in `tax_check()`:
-      ! All arguments must be named.
-      i Currently, there are 2 arguments that should be named.
+      ! All arguments must be named (except for "taxdf").
+      i Currently, there is 1 argument that should be named.
 
 # arg 'name' works
 

--- a/tests/testthat/test-tax_check.R
+++ b/tests/testthat/test-tax_check.R
@@ -11,7 +11,7 @@ test_that("basic behavior works", {
     )
   )
   expect_equal(
-    tax_check(dat),
+    tax_check(taxdf = dat),
     list(
       synonyms = data.frame(
         group = c("F", "J"),
@@ -26,8 +26,16 @@ test_that("basic behavior works", {
   )
 
   # input checks
-  expect_snapshot(tax_check(data.frame()), error = TRUE)
-  expect_snapshot(tax_check(1), error = TRUE)
+  expect_snapshot(tax_check(taxdf = data.frame()), error = TRUE)
+  expect_snapshot(tax_check(taxdf = 1), error = TRUE)
+})
+
+test_that("tax_check errors with unnamed args", {
+  dat <- data.frame(genus = c("Automaton", "Joebloggsia"))
+  expect_snapshot(tax_check(dat, "genus"), error = TRUE)
+  expect_snapshot(tax_check(taxdf = dat, "genus"), error = TRUE)
+  expect_snapshot(tax_check(dat, "genus", NULL), error = TRUE)
+  expect_snapshot(tax_check(dat, "genus", group = NULL), error = TRUE)
 })
 
 test_that("arg 'name' works", {
@@ -44,10 +52,10 @@ test_that("arg 'name' works", {
   )
 
   # default name is "genus"
-  expect_snapshot(tax_check(dat), error = TRUE)
+  expect_snapshot(tax_check(taxdf = dat), error = TRUE)
 
   expect_equal(
-    tax_check(dat, name = "foo"),
+    tax_check(taxdf = dat, name = "foo"),
     list(
       synonyms = data.frame(
         group = c("F", "J"),
@@ -62,11 +70,11 @@ test_that("arg 'name' works", {
   )
 
   # input checks
-  expect_snapshot(tax_check(dat, name = "nonexistent"), error = TRUE)
-  expect_snapshot(tax_check(dat, name = 1), error = TRUE)
-  expect_snapshot(tax_check(dat, name = NULL), error = TRUE)
-  expect_snapshot(tax_check(dat, name = character(0)), error = TRUE)
-  expect_snapshot(tax_check(dat, name = ""), error = TRUE)
+  expect_snapshot(tax_check(taxdf = dat, name = "nonexistent"), error = TRUE)
+  expect_snapshot(tax_check(taxdf = dat, name = 1), error = TRUE)
+  expect_snapshot(tax_check(taxdf = dat, name = NULL), error = TRUE)
+  expect_snapshot(tax_check(taxdf = dat, name = character(0)), error = TRUE)
+  expect_snapshot(tax_check(taxdf = dat, name = ""), error = TRUE)
 })
 
 test_that("arg 'group' works", {
@@ -89,7 +97,7 @@ test_that("arg 'group' works", {
 
   # Without "group", we would have two groups "F" and "J"
   expect_equal(
-    tax_check(dat, group = "family"),
+    tax_check(taxdf = dat, group = "family"),
     list(
       synonyms = data.frame(
         group = "Examplidae",
@@ -104,10 +112,10 @@ test_that("arg 'group' works", {
   )
 
   # input checks
-  expect_snapshot(tax_check(dat, group = "nonexistent"), error = TRUE)
-  expect_snapshot(tax_check(dat, group = 1), error = TRUE)
-  expect_snapshot(tax_check(dat, group = character(0)), error = TRUE)
-  expect_snapshot(tax_check(dat, group = ""), error = TRUE)
+  expect_snapshot(tax_check(taxdf = dat, group = "nonexistent"), error = TRUE)
+  expect_snapshot(tax_check(taxdf = dat, group = 1), error = TRUE)
+  expect_snapshot(tax_check(taxdf = dat, group = character(0)), error = TRUE)
+  expect_snapshot(tax_check(taxdf = dat, group = ""), error = TRUE)
 })
 
 test_that("arg 'dis' works", {
@@ -124,7 +132,7 @@ test_that("arg 'dis' works", {
   )
 
   expect_equal(
-    tax_check(dat, dis = 0.5),
+    tax_check(taxdf = dat, dis = 0.5),
     list(
       synonyms = data.frame(
         group = c("F", "F", "F", "J"),
@@ -139,11 +147,11 @@ test_that("arg 'dis' works", {
   )
 
   # input checks
-  expect_snapshot(tax_check(dat, dis = 1), error = TRUE)
-  expect_snapshot(tax_check(dat, dis = 0), error = TRUE)
-  expect_snapshot(tax_check(dat, dis = "a"), error = TRUE)
-  expect_snapshot(tax_check(dat, dis = numeric(0)), error = TRUE)
-  expect_snapshot(tax_check(dat, dis = NULL), error = TRUE)
+  expect_snapshot(tax_check(taxdf = dat, dis = 1), error = TRUE)
+  expect_snapshot(tax_check(taxdf = dat, dis = 0), error = TRUE)
+  expect_snapshot(tax_check(taxdf = dat, dis = "a"), error = TRUE)
+  expect_snapshot(tax_check(taxdf = dat, dis = numeric(0)), error = TRUE)
+  expect_snapshot(tax_check(taxdf = dat, dis = NULL), error = TRUE)
 })
 
 test_that("arg 'start' works", {
@@ -158,7 +166,7 @@ test_that("arg 'start' works", {
 
   # "Kunlungoides sp" and "Kunmungoides sp" are reported as synonyms
   expect_equal(
-    tax_check(dat),
+    tax_check(taxdf = dat),
     list(
       synonyms = data.frame(
         group = "K",
@@ -175,7 +183,7 @@ test_that("arg 'start' works", {
   # The letter that diverges for "Kunlungoides sp" and "Kunmungoides sp" is the 4th one
   # so this synonym isn't reported if start >= 4
   expect_equal(
-    tax_check(dat, start = 4),
+    tax_check(taxdf = dat, start = 4),
     list(
       synonyms = NULL,
       non_letter_name = NULL,
@@ -184,12 +192,12 @@ test_that("arg 'start' works", {
   )
 
   # input checks
-  expect_snapshot(tax_check(dat, start = -1), error = TRUE)
-  expect_snapshot(tax_check(dat, start = numeric(0)), error = TRUE)
-  expect_snapshot(tax_check(dat, start = "a"), error = TRUE)
+  expect_snapshot(tax_check(taxdf = dat, start = -1), error = TRUE)
+  expect_snapshot(tax_check(taxdf = dat, start = numeric(0)), error = TRUE)
+  expect_snapshot(tax_check(taxdf = dat, start = "a"), error = TRUE)
 
   # TODO: should error
-  # expect_snapshot(tax_check(dat, start = NULL), error = TRUE)
+  # expect_snapshot(tax_check(taxdf = dat, start = NULL), error = TRUE)
 })
 
 test_that("arg 'verbose' works", {
@@ -203,7 +211,7 @@ test_that("arg 'verbose' works", {
   )
 
   expect_equal(
-    tax_check(dat, verbose = FALSE),
+    tax_check(taxdf = dat, verbose = FALSE),
     data.frame(
       group = "K",
       greater = "Kunlungoides sp",
@@ -214,8 +222,8 @@ test_that("arg 'verbose' works", {
   )
 
   # input checks
-  expect_snapshot(tax_check(dat, verbose = 1), error = TRUE)
-  expect_snapshot(tax_check(dat, verbose = numeric(0)), error = TRUE)
-  expect_snapshot(tax_check(dat, verbose = "a"), error = TRUE)
-  expect_snapshot(tax_check(dat, verbose = NULL), error = TRUE)
+  expect_snapshot(tax_check(taxdf = dat, verbose = 1), error = TRUE)
+  expect_snapshot(tax_check(taxdf = dat, verbose = numeric(0)), error = TRUE)
+  expect_snapshot(tax_check(taxdf = dat, verbose = "a"), error = TRUE)
+  expect_snapshot(tax_check(taxdf = dat, verbose = NULL), error = TRUE)
 })

--- a/tests/testthat/test-tax_check.R
+++ b/tests/testthat/test-tax_check.R
@@ -11,7 +11,7 @@ test_that("basic behavior works", {
     )
   )
   expect_equal(
-    tax_check(taxdf = dat),
+    tax_check(dat),
     list(
       synonyms = data.frame(
         group = c("F", "J"),
@@ -31,9 +31,9 @@ test_that("basic behavior works", {
   )
 
   # input checks
-  expect_snapshot(tax_check(taxdf = data.frame()), error = TRUE)
-  expect_snapshot(tax_check(taxdf = 1), error = TRUE)
-  expect_snapshot(tax_check(taxdf = data.frame(genus = c(NA, ""))), error = TRUE)
+  expect_snapshot(tax_check(data.frame()), error = TRUE)
+  expect_snapshot(tax_check(1), error = TRUE)
+  expect_snapshot(tax_check(data.frame(genus = c(NA, ""))), error = TRUE)
 })
 
 test_that("tax_check errors with unnamed args", {
@@ -58,10 +58,10 @@ test_that("arg 'name' works", {
   )
 
   # default name is "genus"
-  expect_snapshot(tax_check(taxdf = dat), error = TRUE)
+  expect_snapshot(tax_check(dat), error = TRUE)
 
   expect_equal(
-    tax_check(taxdf = dat, name = "foo"),
+    tax_check(dat, name = "foo"),
     list(
       synonyms = data.frame(
         group = c("F", "J"),
@@ -76,11 +76,11 @@ test_that("arg 'name' works", {
   )
 
   # input checks
-  expect_snapshot(tax_check(taxdf = dat, name = "nonexistent"), error = TRUE)
-  expect_snapshot(tax_check(taxdf = dat, name = 1), error = TRUE)
-  expect_snapshot(tax_check(taxdf = dat, name = NULL), error = TRUE)
-  expect_snapshot(tax_check(taxdf = dat, name = character(0)), error = TRUE)
-  expect_snapshot(tax_check(taxdf = dat, name = ""), error = TRUE)
+  expect_snapshot(tax_check(dat, name = "nonexistent"), error = TRUE)
+  expect_snapshot(tax_check(dat, name = 1), error = TRUE)
+  expect_snapshot(tax_check(dat, name = NULL), error = TRUE)
+  expect_snapshot(tax_check(dat, name = character(0)), error = TRUE)
+  expect_snapshot(tax_check(dat, name = ""), error = TRUE)
 })
 
 test_that("arg 'group' works", {
@@ -103,7 +103,7 @@ test_that("arg 'group' works", {
 
   # Without "group", we would have two groups "F" and "J"
   expect_equal(
-    tax_check(taxdf = dat, group = "family"),
+    tax_check(dat, group = "family"),
     list(
       synonyms = data.frame(
         group = "Examplidae",
@@ -129,10 +129,10 @@ test_that("arg 'group' works", {
   )
 
   # input checks
-  expect_snapshot(tax_check(taxdf = dat, group = "nonexistent"), error = TRUE)
-  expect_snapshot(tax_check(taxdf = dat, group = 1), error = TRUE)
-  expect_snapshot(tax_check(taxdf = dat, group = character(0)), error = TRUE)
-  expect_snapshot(tax_check(taxdf = dat, group = ""), error = TRUE)
+  expect_snapshot(tax_check(dat, group = "nonexistent"), error = TRUE)
+  expect_snapshot(tax_check(dat, group = 1), error = TRUE)
+  expect_snapshot(tax_check(dat, group = character(0)), error = TRUE)
+  expect_snapshot(tax_check(dat, group = ""), error = TRUE)
 })
 
 test_that("arg 'dis' works", {
@@ -149,7 +149,7 @@ test_that("arg 'dis' works", {
   )
 
   expect_equal(
-    tax_check(taxdf = dat, dis = 0.5),
+    tax_check(dat, dis = 0.5),
     list(
       synonyms = data.frame(
         group = c("F", "F", "F", "J"),
@@ -164,12 +164,12 @@ test_that("arg 'dis' works", {
   )
 
   # input checks
-  expect_snapshot(tax_check(taxdf = dat, dis = 1), error = TRUE)
-  expect_snapshot(tax_check(taxdf = dat, dis = 0), error = TRUE)
-  expect_snapshot(tax_check(taxdf = dat, dis = c(0.5, 0.6)), error = TRUE)
-  expect_snapshot(tax_check(taxdf = dat, dis = "a"), error = TRUE)
-  expect_snapshot(tax_check(taxdf = dat, dis = numeric(0)), error = TRUE)
-  expect_snapshot(tax_check(taxdf = dat, dis = NULL), error = TRUE)
+  expect_snapshot(tax_check(dat, dis = 1), error = TRUE)
+  expect_snapshot(tax_check(dat, dis = 0), error = TRUE)
+  expect_snapshot(tax_check(dat, dis = c(0.5, 0.6)), error = TRUE)
+  expect_snapshot(tax_check(dat, dis = "a"), error = TRUE)
+  expect_snapshot(tax_check(dat, dis = numeric(0)), error = TRUE)
+  expect_snapshot(tax_check(dat, dis = NULL), error = TRUE)
 })
 
 test_that("arg 'start' works", {
@@ -184,7 +184,7 @@ test_that("arg 'start' works", {
 
   # "Kunlungoides sp" and "Kunmungoides sp" are reported as synonyms
   expect_equal(
-    tax_check(taxdf = dat),
+    tax_check(dat),
     list(
       synonyms = data.frame(
         group = "K",
@@ -201,7 +201,7 @@ test_that("arg 'start' works", {
   # The letter that diverges for "Kunlungoides sp" and "Kunmungoides sp" is the 4th one
   # so this synonym isn't reported if start >= 4
   expect_equal(
-    tax_check(taxdf = dat, start = 4),
+    tax_check(dat, start = 4),
     list(
       synonyms = NULL,
       non_letter_name = NULL,
@@ -210,10 +210,10 @@ test_that("arg 'start' works", {
   )
 
   # input checks
-  expect_snapshot(tax_check(taxdf = dat, start = -1), error = TRUE)
-  expect_snapshot(tax_check(taxdf = dat, start = numeric(0)), error = TRUE)
-  expect_snapshot(tax_check(taxdf = dat, start = "a"), error = TRUE)
-  expect_snapshot(tax_check(taxdf = dat, start = NULL), error = TRUE)
+  expect_snapshot(tax_check(dat, start = -1), error = TRUE)
+  expect_snapshot(tax_check(dat, start = numeric(0)), error = TRUE)
+  expect_snapshot(tax_check(dat, start = "a"), error = TRUE)
+  expect_snapshot(tax_check(dat, start = NULL), error = TRUE)
 })
 
 test_that("arg 'verbose' works", {
@@ -227,7 +227,7 @@ test_that("arg 'verbose' works", {
   )
 
   expect_equal(
-    tax_check(taxdf = dat, verbose = FALSE),
+    tax_check(dat, verbose = FALSE),
     data.frame(
       group = "K",
       greater = "Kunlungoides sp",
@@ -238,8 +238,8 @@ test_that("arg 'verbose' works", {
   )
 
   # input checks
-  expect_snapshot(tax_check(taxdf = dat, verbose = 1), error = TRUE)
-  expect_snapshot(tax_check(taxdf = dat, verbose = numeric(0)), error = TRUE)
-  expect_snapshot(tax_check(taxdf = dat, verbose = "a"), error = TRUE)
-  expect_snapshot(tax_check(taxdf = dat, verbose = NULL), error = TRUE)
+  expect_snapshot(tax_check(dat, verbose = 1), error = TRUE)
+  expect_snapshot(tax_check(dat, verbose = numeric(0)), error = TRUE)
+  expect_snapshot(tax_check(dat, verbose = "a"), error = TRUE)
+  expect_snapshot(tax_check(dat, verbose = NULL), error = TRUE)
 })

--- a/tests/testthat/test-tax_check.R
+++ b/tests/testthat/test-tax_check.R
@@ -30,6 +30,24 @@ test_that("basic behavior works", {
   expect_snapshot(tax_check(taxdf = 1), error = TRUE)
 })
 
+test_that("piping and not piping the first argument give the same result", {
+  dat <- data.frame(
+    genus = c(
+      "Automaton",
+      "Joebloggsia",
+      "Facsimilus",
+      "Joebloggia",
+      "Facsimilu",
+      "Facsimilu",
+      NA
+    )
+  )
+  expect_equal(
+    dat |> tax_check(verbose = FALSE),
+    tax_check(dat, verbose = FALSE)
+  )
+})
+
 test_that("tax_check errors with unnamed args", {
   dat <- data.frame(genus = c("Automaton", "Joebloggsia"))
   expect_snapshot(tax_check(dat, "genus"), error = TRUE)

--- a/tests/testthat/test-tax_check.R
+++ b/tests/testthat/test-tax_check.R
@@ -36,6 +36,15 @@ test_that("basic behavior works", {
   expect_snapshot(tax_check(data.frame(genus = c(NA, ""))), error = TRUE)
 })
 
+test_that("piping and not piping the first argument give the same result", {
+  dat <- data.frame(genus = c("Automaton", "Joebloggsia"))
+
+  expect_equal(
+    dat |> tax_check(),
+    tax_check(dat)
+  )
+})
+
 test_that("tax_check errors with unnamed args", {
   dat <- data.frame(genus = c("Automaton", "Joebloggsia"))
   expect_snapshot(tax_check(dat, "genus"), error = TRUE)


### PR DESCRIPTION
This PR and subsequent ones that implement `ensure_args_are_named()` are co-authored by Claude Opus 5.

Part of #216 

## Checklist before requesting a review
- [x] I have read palaeoverse's [standards and structure](https://palaeoverse.palaeoverse.org/articles/structure-and-standards.html)
- [x] I have performed a self-review of my code.
- [ ] I have added function documentation.
- [ ] I have provided sufficient examples of implementation.
- [ ] If it is a core feature, I have added thorough tests.


