### PR TITLE
Allow some arguments to be unnamed

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -1,11 +1,14 @@
 #' Check whether there are unnamed arguments that should be named.
 #'
-#' This errors if some arguments are unnamed or if their names are partially
-#' matched.
+#' This errors if some arguments (apart from `exceptions`) are unnamed or
+#' if their names are partially matched.
+#'
+#' @param exceptions Arguments that can be unnamed.
 #'
 #' @noRd
-ensure_args_are_named <- function() {
+ensure_args_are_named <- function(exceptions = NULL) {
   args_in_call_from_user <- rlang::call_args_names(rlang::caller_call())
+  unnamed_exceptions <- setdiff(exceptions, args_in_call_from_user)
   unnamed_args <- args_in_call_from_user[which(args_in_call_from_user == "")]
   named_args <- args_in_call_from_user[which(
     !is.null(args_in_call_from_user) & args_in_call_from_user != ""
@@ -23,11 +26,18 @@ ensure_args_are_named <- function() {
     )
   }
 
-  if (length(unnamed_args) > 0) {
+  if (length(unnamed_args) > length(unnamed_exceptions)) {
+    extra <- if (length(exceptions) > 0) {
+      " (except for {.val {cli::cli_vec(exceptions)}})"
+    } else {
+      ""
+    }
+    msg <- paste0("All arguments must be named", extra, ".")
+    n <- length(unnamed_args) - length(unnamed_exceptions)
     cli::cli_abort(
       c(
-        "All arguments must be named.",
-        "i" = "Currently, there {?is/are} {length(unnamed_args)} argument{?s} that should be named."
+        msg,
+        "i" = "Currently, there {?is/are} {n} argument{?s} that should be named."
       ),
       call = rlang::caller_env()
     )


### PR DESCRIPTION
This PR allows passing unnamed arguments, which is particularly useful when using the pipe. The only function that has this check for now is `lat_bins_area()` and I don't think we want any unnamed argument (no one would do `12 |> lat_bins_area(min = 90, ...)`, but I checked locally that this works correctly in `bin_lat()`.

Fixes https://github.com/palaeoverse/palaeoverse/issues/319

## Checklist before requesting a review
- [x] I have read palaeoverse's [standards and structure](https://palaeoverse.palaeoverse.org/articles/structure-and-standards.html)
- [x] I have performed a self-review of my code.
- [ ] I have added function documentation.
- [ ] I have provided sufficient examples of implementation.
- [ ] If it is a core feature, I have added thorough tests.

