### PR TITLE
`tax_check()`: remove the `verbose` argument and always return a `data.frame`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,11 @@
 
 * `palaeoverse` requires R >= 4.1.0 (#181).
 
+## Breaking changes
+
+* In `tax_check()`, the argument `verbose` is removed and `tax_check()` always returns
+  a `data.frame` with attributes `non_letter_name` and `non_letter_group` (#342)
+
 ## Bug fixes
 
 * `lat_bins_area()` now errors if `r` is negative or if `min == max` (#321).

--- a/R/tax_check.R
+++ b/R/tax_check.R
@@ -24,25 +24,23 @@
 #' beginning of potential synonyms that should match. Potential synonyms below
 #' this value will not be returned. By default this value is set to 1 (i.e.
 #' the first letter of synonyms must match).
-#' @param verbose \code{logical}. Should the results of the non-letter
-#' character check be reported to the user? If `TRUE`, the result will only be
-#' reported if such characters are detected in the taxon names.
 #'
-#' @return If verbose = `TRUE` (default), a \code{list} with three elements. The
-#' first element in the list (synonyms) is a \code{data.frame} with each row
-#' reporting a pair of potential synonyms. The first column "group" contains the
-#' higher group in which they occur (alphabetical groupings if `group` is
-#' not provided). The second column "greater" contains the most common synonym
-#' in each pair. The third column "lesser" contains the least common synonym in
-#' each pair. The third and fourth column (`count_greater`, `count_lesser`)
-#' contain the respective counts of each synonym in a pair. If no matches were
-#' found for the filtering arguments, this element is `NULL` instead. The second
-#' element (`non_letter_name`) is a vector of taxon names which contain
-#' non-letter characters, or `NULL` if none were detected. The third element
-#' (non_letter_group) is a vector of taxon groups which contain non-letter
-#' characters, or `NULL` if none were detected. If verbose = `FALSE`, a
-#' \code{data.frame} as described above is returned, or `NULL` if no matches
-#' were found.
+#' @return A `data.frame` with each row reporting a pair of potential synonyms
+#' (this `data.frame` can have zero rows), and with the following columns:
+#'
+#' - `"group"` contains the higher group in which they occur (alphabetical groupings
+#'   if `group` is not provided).
+#' - `"greater"` contains the most common synonym in each pair
+#' - `"lesser"` contains the least common synonym in each pair
+#' - `"count_greater"` and `"count_lesser"` contain the respective counts of each
+#'   synonym in a pair.
+#'
+#' This `data.frame` has two attributes:
+#'
+#' - `non_letter_name` is a vector of taxon names which contain non-letter characters,
+#'   or `NULL` if none were detected
+#' - `non_letter_group` is a vector of taxon groups which contain non-letter characters, or
+#'   `NULL` if none were detected.
 #'
 #' @details When higher taxonomy is provided, but some entries are missing,
 #' comparisons will still be made within alphabetical groups of taxa which lack
@@ -87,8 +85,7 @@ tax_check <- function(
   name = "genus",
   group = NULL,
   dis = 0.05,
-  start = 1,
-  verbose = TRUE
+  start = 1
 ) {
   # ARGUMENT CHECKS --------------------------------------------------------- #
 
@@ -122,22 +119,10 @@ tax_check <- function(
   }
 
   rlang::check_number_whole(start, min = 0)
-  rlang::check_bool(verbose)
 
-  # check for non-letter characters, returning NULL if none
+  # check for non-letter characters
   gp <- unique(grep("[^[:alpha:] ]", group, value = TRUE))
-  if (length(gp) != 0) {
-    cli::cli_warn("Non-letter characters present in the group names.")
-  } else {
-    gp <- NULL
-  }
-
   nm <- unique(grep("[^[:alpha:] ]", taxdf[, name, drop = TRUE], value = TRUE))
-  if (length(nm) != 0) {
-    cli::cli_warn("Non-letter characters present in the taxon names.")
-  } else {
-    nm <- NULL
-  }
 
   # FORMAT INPUT DATA ------------------------------------------------------- #
 
@@ -207,48 +192,69 @@ tax_check <- function(
   # FORMAT OUTPUT ----------------------------------------------------------- #
 
   # format initial results data.frame from list
-  err <- sp[!unlist(lapply(sp, is.null))]
-  err <- as.data.frame(do.call(rbind, err))
-  err$f1 <- as.vector(table(taxdf2[, "name"])[match(
-    err$V1,
+  out <- sp[!unlist(lapply(sp, is.null))]
+  out <- as.data.frame(do.call(rbind, out))
+  out$f1 <- as.vector(table(taxdf2[, "name"])[match(
+    out$V1,
     names(table(
       taxdf2[, "name"]
     ))
   )])
-  err$f2 <- as.vector(table(taxdf2[, "name"])[match(
-    err$V2,
+  out$f2 <- as.vector(table(taxdf2[, "name"])[match(
+    out$V2,
     names(table(
       taxdf2[, "name"]
     ))
   )])
 
   # NULL if no matches present
-  if (nrow(err) == 0) {
-    err <- NULL
+  if (nrow(out) == 0) {
+    out <- data.frame(
+      group = character(0),
+      greater = character(0),
+      lesser = character(0),
+      count_greater = integer(0),
+      count_lesser = integer(0)
+    )
 
     # else reorder rows so the more frequent synonym is in the first column
   } else {
-    mins <- apply(err[, 4:5], 1, which.min) - 1
+    mins <- apply(out[, 4:5], 1, which.min) - 1
     maxs <- abs(mins - 1)
-    fq1 <- unlist(err[, 4:5])[seq_along(maxs) + (maxs * length(maxs))]
-    fq2 <- unlist(err[, 4:5])[seq_along(mins) + (mins * length(mins))]
-    mins <- unlist(err[, 1:2])[seq_along(mins) + (mins * length(mins))]
-    maxs <- unlist(err[, 1:2])[seq_along(maxs) + (maxs * length(maxs))]
-    err <- data.frame(
-      group = err$y,
+    fq1 <- unlist(out[, 4:5])[seq_along(maxs) + (maxs * length(maxs))]
+    fq2 <- unlist(out[, 4:5])[seq_along(mins) + (mins * length(mins))]
+    mins <- unlist(out[, 1:2])[seq_along(mins) + (mins * length(mins))]
+    maxs <- unlist(out[, 1:2])[seq_along(maxs) + (maxs * length(maxs))]
+    out <- data.frame(
+      group = out$y,
       greater = as.vector(maxs),
       lesser = as.vector(mins),
       count_greater = fq1,
       count_lesser = fq2
     )
-    err <- err[order(err[, "group"], err[, "greater"], method = "radix"), ]
-    row.names(err) <- NULL
+    out <- out[order(out[, "group"], out[, "greater"], method = "radix"), ]
+    row.names(out) <- NULL
   }
 
-  # return
-  if (verbose) {
-    return(list(synonyms = err, non_letter_name = nm, non_letter_group = gp))
-  } else {
-    return(err)
+  if (length(nm) > 0) {
+    cli::cli_warn(
+      c(
+        "Some names had non-letter characters.",
+        "i" = "See which ones with {.code attr(<output>, \"non_letter_name\")}."
+      )
+    )
+    attr(out, "non_letter_name") <- nm
   }
+  if (length(gp) > 0) {
+    browser
+    cli::cli_warn(
+      c(
+        "Some groups had non-letter characters.",
+        "i" = "See which ones with {.code attr(<output>, \"non_letter_group\")}."
+      )
+    )
+    attr(out, "non_letter_group") <- gp
+  }
+
+  out
 }

--- a/R/tax_check.R
+++ b/R/tax_check.R
@@ -248,7 +248,6 @@ tax_check <- function(
     attr(out, "non_letter_name") <- nm
   }
   if (length(gp) > 0) {
-    browser
     cli::cli_warn(
       c(
         "Some groups had non-letter characters.",

--- a/R/tax_check.R
+++ b/R/tax_check.R
@@ -46,9 +46,11 @@
 #' comparisons will still be made within alphabetical groups of taxa which lack
 #' higher taxonomic affiliations. The function also performs a check for
 #' non-letter characters which are not expected to be present in
-#' correctly-formatted taxon names. This detection may be made available to the
-#' user via the `verbose` argument. Comparisons are performed using the
-#' Jaro dissimilarity metric via
+#' correctly-formatted taxon names. Names and groups that contain non-letter
+#' characters can be found with `attr(<output> "non_letter_name")` and
+#' `attr(<output> "non_letter_group")` respectively.
+#'
+#' Comparisons are performed using the Jaro dissimilarity metric via
 #' \code{\link[stringdist:stringdistmatrix]{stringdist::stringdistmatrix()}}.
 #'
 #' As all string distance metrics rely on approximate string matching,

--- a/man/tax_check.Rd
+++ b/man/tax_check.Rd
@@ -62,9 +62,11 @@ When higher taxonomy is provided, but some entries are missing,
 comparisons will still be made within alphabetical groups of taxa which lack
 higher taxonomic affiliations. The function also performs a check for
 non-letter characters which are not expected to be present in
-correctly-formatted taxon names. This detection may be made available to the
-user via the \code{verbose} argument. Comparisons are performed using the
-Jaro dissimilarity metric via
+correctly-formatted taxon names. Names and groups that contain non-letter
+characters can be found with \verb{attr(<output> "non_letter_name")} and
+\verb{attr(<output> "non_letter_group")} respectively.
+
+Comparisons are performed using the Jaro dissimilarity metric via
 \code{\link[stringdist:stringdistmatrix]{stringdist::stringdistmatrix()}}.
 
 As all string distance metrics rely on approximate string matching,

--- a/man/tax_check.Rd
+++ b/man/tax_check.Rd
@@ -4,14 +4,7 @@
 \alias{tax_check}
 \title{Taxonomic spell check}
 \usage{
-tax_check(
-  taxdf,
-  name = "genus",
-  group = NULL,
-  dis = 0.05,
-  start = 1,
-  verbose = TRUE
-)
+tax_check(taxdf, name = "genus", group = NULL, dis = 0.05, start = 1)
 }
 \arguments{
 \item{taxdf}{\code{data.frame}. A dataframe with named columns containing
@@ -38,27 +31,26 @@ with this value for their specific data.}
 beginning of potential synonyms that should match. Potential synonyms below
 this value will not be returned. By default this value is set to 1 (i.e.
 the first letter of synonyms must match).}
-
-\item{verbose}{\code{logical}. Should the results of the non-letter
-character check be reported to the user? If \code{TRUE}, the result will only be
-reported if such characters are detected in the taxon names.}
 }
 \value{
-If verbose = \code{TRUE} (default), a \code{list} with three elements. The
-first element in the list (synonyms) is a \code{data.frame} with each row
-reporting a pair of potential synonyms. The first column "group" contains the
-higher group in which they occur (alphabetical groupings if \code{group} is
-not provided). The second column "greater" contains the most common synonym
-in each pair. The third column "lesser" contains the least common synonym in
-each pair. The third and fourth column (\code{count_greater}, \code{count_lesser})
-contain the respective counts of each synonym in a pair. If no matches were
-found for the filtering arguments, this element is \code{NULL} instead. The second
-element (\code{non_letter_name}) is a vector of taxon names which contain
-non-letter characters, or \code{NULL} if none were detected. The third element
-(non_letter_group) is a vector of taxon groups which contain non-letter
-characters, or \code{NULL} if none were detected. If verbose = \code{FALSE}, a
-\code{data.frame} as described above is returned, or \code{NULL} if no matches
-were found.
+A \code{data.frame} with each row reporting a pair of potential synonyms
+(this \code{data.frame} can have zero rows), and with the following columns:
+\itemize{
+\item \code{"group"} contains the higher group in which they occur (alphabetical groupings
+if \code{group} is not provided).
+\item \code{"greater"} contains the most common synonym in each pair
+\item \code{"lesser"} contains the least common synonym in each pair
+\item \code{"count_greater"} and \code{"count_lesser"} contain the respective counts of each
+synonym in a pair.
+}
+
+This \code{data.frame} has two attributes:
+\itemize{
+\item \code{non_letter_name} is a vector of taxon names which contain non-letter characters,
+or \code{NULL} if none were detected
+\item \code{non_letter_group} is a vector of taxon groups which contain non-letter characters, or
+\code{NULL} if none were detected.
+}
 }
 \description{
 A function to check for and count potential spelling variations of the same

--- a/tests/testthat/_snaps/tax_check.md
+++ b/tests/testthat/_snaps/tax_check.md
@@ -4,18 +4,11 @@
       tax_check(data.frame(genus = c("Automaton", "Automaton2")))
     Condition
       Warning:
-      Non-letter characters present in the taxon names.
+      Some names had non-letter characters.
+      i See which ones with `attr(<output>, "non_letter_name")`.
     Output
-      $synonyms
         group   greater     lesser count_greater count_lesser
       1     A Automaton Automaton2             1            1
-      
-      $non_letter_name
-      [1] "Automaton2"
-      
-      $non_letter_group
-      NULL
-      
 
 ---
 
@@ -96,17 +89,11 @@
         "Examplidae2")), group = "family")
     Condition
       Warning:
-      Non-letter characters present in the group names.
+      Some groups had non-letter characters.
+      i See which ones with `attr(<output>, "non_letter_group")`.
     Output
-      $synonyms
-      NULL
-      
-      $non_letter_name
-      NULL
-      
-      $non_letter_group
-      [1] "Examplidae2"
-      
+      [1] group         greater       lesser        count_greater count_lesser 
+      <0 rows> (or 0-length row.names)
 
 ---
 
@@ -219,36 +206,4 @@
     Condition
       Error in `tax_check()`:
       ! `start` must be a whole number, not `NULL`.
-
-# arg 'verbose' works
-
-    Code
-      tax_check(dat, verbose = 1)
-    Condition
-      Error in `tax_check()`:
-      ! `verbose` must be `TRUE` or `FALSE`, not the number 1.
-
----
-
-    Code
-      tax_check(dat, verbose = numeric(0))
-    Condition
-      Error in `tax_check()`:
-      ! `verbose` must be `TRUE` or `FALSE`, not an empty numeric vector.
-
----
-
-    Code
-      tax_check(dat, verbose = "a")
-    Condition
-      Error in `tax_check()`:
-      ! `verbose` must be `TRUE` or `FALSE`, not the string "a".
-
----
-
-    Code
-      tax_check(dat, verbose = NULL)
-    Condition
-      Error in `tax_check()`:
-      ! `verbose` must be `TRUE` or `FALSE`, not `NULL`.
 

--- a/tests/testthat/test-tax_check.R
+++ b/tests/testthat/test-tax_check.R
@@ -12,16 +12,12 @@ test_that("basic behavior works", {
   )
   expect_equal(
     tax_check(dat),
-    list(
-      synonyms = data.frame(
-        group = c("F", "J"),
-        greater = c("Facsimilu", "Joebloggsia"),
-        lesser = c("Facsimilus", "Joebloggia"),
-        count_greater = c(2, 1),
-        count_lesser = 1
-      ),
-      non_letter_name = NULL,
-      non_letter_group = NULL
+    data.frame(
+      group = c("F", "J"),
+      greater = c("Facsimilu", "Joebloggsia"),
+      lesser = c("Facsimilus", "Joebloggia"),
+      count_greater = c(2, 1),
+      count_lesser = 1
     )
   )
 
@@ -54,16 +50,12 @@ test_that("arg 'name' works", {
 
   expect_equal(
     tax_check(dat, name = "foo"),
-    list(
-      synonyms = data.frame(
-        group = c("F", "J"),
-        greater = c("Facsimilu", "Joebloggsia"),
-        lesser = c("Facsimilus", "Joebloggia"),
-        count_greater = c(2, 1),
-        count_lesser = 1
-      ),
-      non_letter_name = NULL,
-      non_letter_group = NULL
+    data.frame(
+      group = c("F", "J"),
+      greater = c("Facsimilu", "Joebloggsia"),
+      lesser = c("Facsimilus", "Joebloggia"),
+      count_greater = c(2, 1),
+      count_lesser = 1
     )
   )
 
@@ -96,16 +88,12 @@ test_that("arg 'group' works", {
   # Without "group", we would have two groups "F" and "J"
   expect_equal(
     tax_check(dat, group = "family"),
-    list(
-      synonyms = data.frame(
-        group = "Examplidae",
-        greater = "Facsimilu",
-        lesser = "Facsimilus",
-        count_greater = 2L,
-        count_lesser = 1L
-      ),
-      non_letter_name = NULL,
-      non_letter_group = NULL
+    data.frame(
+      group = "Examplidae",
+      greater = "Facsimilu",
+      lesser = "Facsimilus",
+      count_greater = 2L,
+      count_lesser = 1L
     )
   )
 
@@ -142,16 +130,12 @@ test_that("arg 'dis' works", {
 
   expect_equal(
     tax_check(dat, dis = 0.5),
-    list(
-      synonyms = data.frame(
-        group = c("F", "F", "F", "J"),
-        greater = c("Facsimilu", "Facsimilus", "Facsimilus", "Joebloggsia"),
-        lesser = c("Facstlwe", "Facsimilu", "Facstlwe", "Joebloggia"),
-        count_greater = 1L,
-        count_lesser = 1L
-      ),
-      non_letter_name = NULL,
-      non_letter_group = NULL
+    data.frame(
+      group = c("F", "F", "F", "J"),
+      greater = c("Facsimilu", "Facsimilus", "Facsimilus", "Joebloggsia"),
+      lesser = c("Facstlwe", "Facsimilu", "Facstlwe", "Joebloggia"),
+      count_greater = 1L,
+      count_lesser = 1L
     )
   )
 
@@ -177,49 +161,6 @@ test_that("arg 'start' works", {
   # "Kunlungoides sp" and "Kunmungoides sp" are reported as synonyms
   expect_equal(
     tax_check(dat),
-    list(
-      synonyms = data.frame(
-        group = "K",
-        greater = "Kunlungoides sp",
-        lesser = "Kunmungoides sp",
-        count_greater = 1L,
-        count_lesser = 1L
-      ),
-      non_letter_name = NULL,
-      non_letter_group = NULL
-    )
-  )
-
-  # The letter that diverges for "Kunlungoides sp" and "Kunmungoides sp" is the 4th one
-  # so this synonym isn't reported if start >= 4
-  expect_equal(
-    tax_check(dat, start = 4),
-    list(
-      synonyms = NULL,
-      non_letter_name = NULL,
-      non_letter_group = NULL
-    )
-  )
-
-  # input checks
-  expect_snapshot(tax_check(dat, start = -1), error = TRUE)
-  expect_snapshot(tax_check(dat, start = numeric(0)), error = TRUE)
-  expect_snapshot(tax_check(dat, start = "a"), error = TRUE)
-  expect_snapshot(tax_check(dat, start = NULL), error = TRUE)
-})
-
-test_that("arg 'verbose' works", {
-  dat <- data.frame(
-    genus = c(
-      "Automaton",
-      "Kunlungoides sp",
-      "Kunmungoides sp",
-      NA
-    )
-  )
-
-  expect_equal(
-    tax_check(dat, verbose = FALSE),
     data.frame(
       group = "K",
       greater = "Kunlungoides sp",
@@ -229,9 +170,22 @@ test_that("arg 'verbose' works", {
     )
   )
 
+  # The letter that diverges for "Kunlungoides sp" and "Kunmungoides sp" is the 4th one
+  # so this synonym isn't reported if start >= 4
+  expect_equal(
+    tax_check(dat, start = 4),
+    data.frame(
+      group = character(0),
+      greater = character(0),
+      lesser = character(0),
+      count_greater = integer(0),
+      count_lesser = integer(0)
+    )
+  )
+
   # input checks
-  expect_snapshot(tax_check(dat, verbose = 1), error = TRUE)
-  expect_snapshot(tax_check(dat, verbose = numeric(0)), error = TRUE)
-  expect_snapshot(tax_check(dat, verbose = "a"), error = TRUE)
-  expect_snapshot(tax_check(dat, verbose = NULL), error = TRUE)
+  expect_snapshot(tax_check(dat, start = -1), error = TRUE)
+  expect_snapshot(tax_check(dat, start = numeric(0)), error = TRUE)
+  expect_snapshot(tax_check(dat, start = "a"), error = TRUE)
+  expect_snapshot(tax_check(dat, start = NULL), error = TRUE)
 })


### PR DESCRIPTION
Part of #355 

This removes the `verbose` parameter and always returns a `data.frame` with attributes.

