### PR TITLE
[WIP] Explore using `h3o` instead of `h3jsr`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -51,7 +51,7 @@ Imports:
     curl,
     geosphere,
     graphics,
-    h3jsr (>= 1.3.0),
+    h3o,
     httr,
     lifecycle,
     methods,

--- a/R/space_bins.R
+++ b/R/space_bins.R
@@ -7,22 +7,25 @@ space_bins <- function(spacing) {
 
   # Generate equal area hexagonal grid
   # Which resolution should be used based on input distance/spacing?
-  # Use the h3jsr::h3_info_table to calculate resolution
-  grid <- h3jsr::h3_info_table[
-    which.min(abs(h3jsr::h3_info_table$avg_cendist_km - spacing)),
+  # Use the h3_info_table to calculate resolution
+
+  grid <- h3_info_table[
+    which.min(abs(h3_info_table$avg_cendist_km - spacing)),
   ]
   # Add column grid specification
   grid$grid <- c("primary")
 
-  all_cells <- h3jsr::get_res0()
+  all_cells <- h3o::h3_from_strings(h3_all_cells)
+
   # Get children at desired resolution
-  children <- h3jsr::get_children(
-    h3_address = all_cells,
-    res = grid$h3_resolution,
-    simple = TRUE
+  children <- h3o::get_children(
+    all_cells,
+    resolution = grid$h3_resolution
   )
-  # Get base cells
-  out <- h3jsr::cell_to_polygon(input = children, simple = TRUE)
+  out <- do.call(
+    "c",
+    lapply(children, function(x) sf::st_as_sfc(x))
+  )
 
   class(out) <- c("palaeo_space_bins", class(out))
   attr(out, "spacing") <- spacing
@@ -31,3 +34,86 @@ space_bins <- function(spacing) {
 
   out
 }
+
+# Extracted from h3jsr::h3_info_table
+# fmt: skip
+h3_info_table <- data.frame(
+  h3_resolution = 0:15,
+  avg_area_sqm = c(
+    4357449416078.39, 609788441794.1339, 86801780398.99731, 12393434655.08818,
+    1770347654.491309, 252903858.1819452, 36129062.1644125, 5161293.359717198,
+    737327.5975944188, 105332.5134272069, 15047.50190766437, 2149.643129451882,
+    307.0918756316063, 43.87026794728301, 6.267181135324322, 0.8953115907605802
+  ),
+  avg_area_sqkm = c(
+    4357449.416078383, 609788.4417941332, 86801.7803989972, 12393.43465508816,
+    1770.347654491307, 252.9038581819449, 36.12906216441245, 5.161293359717191,
+    0.7373275975944177, 0.1053325134272067, 0.01504750190766435,
+    0.002149643129451879, 0.000307091875631606, 4.387026794728296e-05,
+    6.267181135324313e-06, 8.95311590760579e-07
+  ),
+  avg_edge_m = c(
+    1107712.591, 418676.0055, 158244.6558, 59810.85794, 22606.3794, 8544.408276,
+    3229.482772, 1220.629759, 461.3546837, 174.3756681, 65.90780749, 24.9105614,
+    9.415526211, 3.559893033, 1.348574562, 0.509713273
+  ),
+  avg_edge_km = c(
+    1107.712591, 418.6760055, 158.2446558, 59.81085794, 22.6063794, 8.544408276,
+    3.229482772, 1.220629759, 0.461354684, 0.174375668, 0.065907807, 0.024910561,
+    0.009415526, 0.003559893, 0.001348575, 0.000509713
+  ),
+  avg_cendist_m = c(
+    1918614.4877957636, 725168.1134359868, 274087.78387184907, 103595.4447963644,
+    39155.397695978434, 14799.349254644, 5593.6282432723765, 2114.192759818554,
+    799.089752478269, 302.0275167529676, 114.1556711881486, 43.1463579898641,
+    16.30816977744848, 6.16591560266647, 2.3357996591789454, 0.8828492861282258
+  ),
+  avg_cendist_km = c(
+    1918.6144877957636, 725.1681134359867, 274.08778387184907, 103.5954447963644,
+    39.155397695978436, 14.799349254644, 5.593628243272376, 2.114192759818554,
+    0.7990897529978843, 0.30202751657976246, 0.11415567033944371,
+    0.04314635729704378, 0.016308169411985762, 0.006165915545508794,
+    0.002335800417817199, 0.0008828488132783551
+  ),
+  total_unique_indexes = c(
+    122, 842, 5882, 41162, 288122, 2016842, 14117882, 98825162, 691776122,
+    4842432842, 33897029882, 237279209162, 1660954464122, 11626681248842,
+    81386768741882, 569707381193162
+  )
+)
+
+# Extracted from h3jsr::get_res0()
+# fmt: skip
+h3_all_cells <- c(
+  "8001fffffffffff", "8003fffffffffff", "8005fffffffffff", "8007fffffffffff",
+  "8009fffffffffff", "800bfffffffffff", "800dfffffffffff", "800ffffffffffff",
+  "8011fffffffffff", "8013fffffffffff", "8015fffffffffff", "8017fffffffffff",
+  "8019fffffffffff", "801bfffffffffff", "801dfffffffffff", "801ffffffffffff",
+  "8021fffffffffff", "8023fffffffffff", "8025fffffffffff", "8027fffffffffff",
+  "8029fffffffffff", "802bfffffffffff", "802dfffffffffff", "802ffffffffffff",
+  "8031fffffffffff", "8033fffffffffff", "8035fffffffffff", "8037fffffffffff",
+  "8039fffffffffff", "803bfffffffffff", "803dfffffffffff", "803ffffffffffff",
+  "8041fffffffffff", "8043fffffffffff", "8045fffffffffff", "8047fffffffffff",
+  "8049fffffffffff", "804bfffffffffff", "804dfffffffffff", "804ffffffffffff",
+  "8051fffffffffff", "8053fffffffffff", "8055fffffffffff", "8057fffffffffff",
+  "8059fffffffffff", "805bfffffffffff", "805dfffffffffff", "805ffffffffffff",
+  "8061fffffffffff", "8063fffffffffff", "8065fffffffffff", "8067fffffffffff",
+  "8069fffffffffff", "806bfffffffffff", "806dfffffffffff", "806ffffffffffff",
+  "8071fffffffffff", "8073fffffffffff", "8075fffffffffff", "8077fffffffffff",
+  "8079fffffffffff", "807bfffffffffff", "807dfffffffffff", "807ffffffffffff",
+  "8081fffffffffff", "8083fffffffffff", "8085fffffffffff", "8087fffffffffff",
+  "8089fffffffffff", "808bfffffffffff", "808dfffffffffff", "808ffffffffffff",
+  "8091fffffffffff", "8093fffffffffff", "8095fffffffffff", "8097fffffffffff",
+  "8099fffffffffff", "809bfffffffffff", "809dfffffffffff", "809ffffffffffff",
+  "80a1fffffffffff", "80a3fffffffffff", "80a5fffffffffff", "80a7fffffffffff",
+  "80a9fffffffffff", "80abfffffffffff", "80adfffffffffff", "80affffffffffff",
+  "80b1fffffffffff", "80b3fffffffffff", "80b5fffffffffff", "80b7fffffffffff",
+  "80b9fffffffffff", "80bbfffffffffff", "80bdfffffffffff", "80bffffffffffff",
+  "80c1fffffffffff", "80c3fffffffffff", "80c5fffffffffff", "80c7fffffffffff",
+  "80c9fffffffffff", "80cbfffffffffff", "80cdfffffffffff", "80cffffffffffff",
+  "80d1fffffffffff", "80d3fffffffffff", "80d5fffffffffff", "80d7fffffffffff",
+  "80d9fffffffffff", "80dbfffffffffff", "80ddfffffffffff", "80dffffffffffff",
+  "80e1fffffffffff", "80e3fffffffffff", "80e5fffffffffff", "80e7fffffffffff",
+  "80e9fffffffffff", "80ebfffffffffff", "80edfffffffffff", "80effffffffffff",
+  "80f1fffffffffff", "80f3fffffffffff"
+)

--- a/R/space_bins.R
+++ b/R/space_bins.R
@@ -8,7 +8,6 @@ space_bins <- function(spacing) {
   # Generate equal area hexagonal grid
   # Which resolution should be used based on input distance/spacing?
   # Use the h3_info_table to calculate resolution
-
   grid <- h3_info_table[
     which.min(abs(h3_info_table$avg_cendist_km - spacing)),
   ]
@@ -16,16 +15,12 @@ space_bins <- function(spacing) {
   grid$grid <- c("primary")
 
   all_cells <- h3o::h3_from_strings(h3_all_cells)
-
   # Get children at desired resolution
   children <- h3o::get_children(
     all_cells,
     resolution = grid$h3_resolution
   )
-  out <- do.call(
-    "c",
-    lapply(children, function(x) sf::st_as_sfc(x))
-  )
+  out <- do.call("c", lapply(children, function(x) sf::st_as_sfc(x)))
 
   class(out) <- c("palaeo_space_bins", class(out))
   attr(out, "spacing") <- spacing

--- a/man/bin_space.Rd
+++ b/man/bin_space.Rd
@@ -4,15 +4,7 @@
 \alias{bin_space}
 \title{Assign fossil occurrences to spatial bins}
 \usage{
-bin_space(
-  occdf,
-  lng = "lng",
-  lat = "lat",
-  spacing = 100,
-  sub_grid = NULL,
-  return = FALSE,
-  plot = FALSE
-)
+bin_space(occdf, bins, lng = "lng", lat = "lat")
 }
 \arguments{
 \item{occdf}{\code{dataframe}. A dataframe of the fossil occurrences (or


### PR DESCRIPTION
Just exploring for now, related to #162.

Main problem with `h3o`: it requires R >= 4.2 (but if we bump one R version per year then we'll also require R >= 4.2 next year).

`h3o` has way less dependencies and is much faster than `h3jsr`:

``` r
nrow(pak::pkg_deps("h3jsr"))
#> [1] 35
nrow(pak::pkg_deps("h3o"))
#> [1] 6
```

Benchmarks to compare this branch to #344 (using [`cross`](https://github.com/davisvaughan/cross)). In each benchmark, the first result is #344 and the second one is this branch:

``` r
cross::bench_versions(
  pkgs = c("palaeoverse/palaeoverse@space_bins", "palaeoverse/palaeoverse@space-bins-h3o"), 
  {
    library(palaeoverse)
    bench::mark(space_bins(500))
  }
)
#> # A tibble: 2 × 7
#>   pkg                      expression    min median `itr/sec` mem_alloc `gc/sec`
#>   <chr>                    <bch:expr> <bch:> <bch:>     <dbl> <bch:byt>    <dbl>
#> 1 palaeoverse/palaeoverse… space_bin… 81.5ms 92.4ms      10.6    2.22MB     51.3
#> 2 palaeoverse/palaeoverse… space_bin… 26.4ms 32.4ms      27.6    1.55MB     37.5
```
``` r
cross::bench_versions(
  pkgs = c("palaeoverse/palaeoverse@space_bins", "palaeoverse/palaeoverse@space-bins-h3o"), 
  {
    library(palaeoverse)
    bench::mark(space_bins(100))
  }
)
#> # A tibble: 2 × 7
#>   pkg                       expression   min median `itr/sec` mem_alloc `gc/sec`
#>   <chr>                     <bch:expr> <bch> <bch:>     <dbl> <bch:byt>    <dbl>
#> 1 palaeoverse/palaeoverse@… space_bin…    4s     4s     0.250   37.23MB    12.0 
#> 2 palaeoverse/palaeoverse@… space_bin… 208ms  252ms     3.97     8.72MB     7.94
```

``` r
cross::bench_versions(
  pkgs = c("palaeoverse/palaeoverse@space_bins", "palaeoverse/palaeoverse@space-bins-h3o"), 
  {
    library(palaeoverse)
    bench::mark(space_bins(50))
  }
)
#> # A tibble: 2 × 7
#>   pkg                      expression    min median `itr/sec` mem_alloc `gc/sec`
#>   <chr>                    <bch:expr> <bch:> <bch:>     <dbl> <bch:byt>    <dbl>
#> 1 palaeoverse/palaeoverse… space_bin… 32.56s 32.56s    0.0307     252MB     1.90
#> 2 palaeoverse/palaeoverse… space_bin…  2.37s  2.37s    0.422     53.7MB     1.27
```

## Checklist before requesting a review
- [ ] I have read palaeoverse's [standards and structure](https://palaeoverse.palaeoverse.org/articles/structure-and-standards.html)
- [ ] I have performed a self-review of my code.
- [ ] I have added function documentation.
- [ ] I have provided sufficient examples of implementation.
- [ ] If it is a core feature, I have added thorough tests.

