### PR TITLE
Add `NEWS` item for mandatory named arguments

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,7 +14,7 @@
   # Partial argument names are not allowed
   tax_certainty(taxdf, nam = "identified_name")
   ```
-  This should be used instead:o
+  This should be used instead:
 
   ```r
   tax_certainty(taxdf, name = "identified_name")

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # palaeoverse (development version)
 
-This version contains many breaking changes. See the [2.0 migration guide]() for
+This version contains many breaking changes. See the 2.0 migration guide for
 guidance to update existing code.
 
 ## Breaking changes

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,16 +8,16 @@
   argument is a `data.frame` (#216). For example, the following cases would fail:
 
   ```r
-  # `occdf` can be unnamed, but `nrow` must be named
-  group_apply(occdf, group = "cc", nrow)
+  # `taxdf` can be unnamed, but `identified_name` must be named
+  tax_certainty(taxdf, "identified_name")
 
   # Partial argument names are not allowed
-  group_apply(occdf, group = "cc", f = nrow)
+  tax_certainty(taxdf, nam = "identified_name")
   ```
-  This should be used instead:
+  This should be used instead:o
 
   ```r
-  group_apply(occdf, group = "cc", fun = nrow)
+  tax_certainty(taxdf, name = "identified_name")
   ```
 
 ## Bug fixes

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,24 +1,14 @@
 # palaeoverse (development version)
 
-* `palaeoverse` requires R >= 4.1.0 (#181).
+This version contains many breaking changes. See the [2.0 migration guide]() for
+guidance to update existing code.
 
 ## Breaking changes
 
-* All functions now require arguments to be fully named, except when the first 
-  argument is a `data.frame` (#216). For example, the following cases would fail:
+* `palaeoverse` requires R >= 4.1.0 (#181).
 
-  ```r
-  # `taxdf` can be unnamed, but `identified_name` must be named
-  tax_certainty(taxdf, "identified_name")
-
-  # Partial argument names are not allowed
-  tax_certainty(taxdf, nam = "identified_name")
-  ```
-  This should be used instead:
-
-  ```r
-  tax_certainty(taxdf, name = "identified_name")
-  ```
+* All functions now require arguments to be fully named, except for the first 
+  argument in some cases (#216).
 
 ## Bug fixes
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,24 @@
 
 * `palaeoverse` requires R >= 4.1.0 (#181).
 
+## Breaking changes
+
+* All functions now require arguments to be fully named, except when the first 
+  argument is a `data.frame` (#216). For example, the following cases would fail:
+
+  ```r
+  # `occdf` can be unnamed, but `nrow` must be named
+  group_apply(occdf, group = "cc", nrow)
+
+  # Partial argument names are not allowed
+  group_apply(occdf, group = "cc", f = nrow)
+  ```
+  This should be used instead:
+
+  ```r
+  group_apply(occdf, group = "cc", fun = nrow)
+  ```
+
 ## Bug fixes
 
 * `lat_bins_area()` now errors if `r` is negative or if `min == max` (#321).


### PR DESCRIPTION
Part of #216 

On top of the NEWS item, I don't really see where to document this in a general way. One way to do it would be to have an empty reference page that would just explain this behaviour and provide a list of which arguments don't have to be named in each function, but I'm not convinced this page would be easy to find. We could also say that error messages are clear enough.

## Checklist before requesting a review
- [x] I have read palaeoverse's [standards and structure](https://palaeoverse.palaeoverse.org/articles/structure-and-standards.html)
- [x] I have performed a self-review of my code.
- [ ] I have added function documentation.
- [ ] I have provided sufficient examples of implementation.
- [ ] If it is a core feature, I have added thorough tests.

