### PR TITLE
Rename args `occdf` and `taxdf` to `data`

### DIFF
--- a/R/bin_lat.R
+++ b/R/bin_lat.R
@@ -2,7 +2,7 @@
 #'
 #' A function to assign fossil occurrences to user-specified latitudinal bins.
 #'
-#' @param occdf `dataframe`. A dataframe of the fossil occurrences you
+#' @param data `dataframe`. A dataframe of the fossil occurrences you
 #' wish to bin. This dataframe should contain a column with the
 #' latitudinal coordinates of occurrence data.
 #' @param bins `dataframe`. A dataframe of the bins that you wish to
@@ -18,7 +18,7 @@
 #' If `FALSE`, occurrences will be binned into the upper bin
 #' only (i.e. highest row number).
 #'
-#' @return A dataframe of the original input `occdf` with appended
+#' @return A dataframe of the original input `data` with appended
 #' columns containing respective latitudinal bin information.
 #'
 #' @section Developer(s):
@@ -28,44 +28,44 @@
 #' @export
 #' @examples
 #' # Load occurrence data
-#' occdf <- tetrapods
+#' data <- tetrapods
 #' # Generate latitudinal bins
 #' bins <- lat_bins_degrees(size = 10)
 #' # Bin data
-#' occdf <- bin_lat(occdf = occdf, bins = bins, lat = "lat")
+#' data <- bin_lat(data = data, bins = bins, lat = "lat")
 #'
-bin_lat <- function(occdf, bins, lat = "lat", boundary = FALSE) {
+bin_lat <- function(data, bins, lat = "lat", boundary = FALSE) {
   ensure_args_are_named()
 
-  check_data_frame(occdf)
+  check_data_frame(data)
   check_data_frame(bins)
   rlang::check_bool(boundary)
-  check_column_presence(occdf, lat)
+  check_column_presence(data, lat)
   check_column_presence(bins, "min")
   check_column_presence(bins, "max")
   check_column_presence(bins, "bin")
 
-  lat_vals <- occdf[[lat]]
-  check_na(occdf, lat)
-  check_range(occdf, lat, -90, 90)
+  lat_vals <- data[[lat]]
+  check_na(data, lat)
+  check_range(data, lat, -90, 90)
 
   #=== Set up ===
   # Add mid bin
   bins$mid <- (bins$max + bins$min) / 2
-  occdf$lat_bin <- NA
-  occdf$lat_max <- NA
-  occdf$lat_mid <- NA
-  occdf$lat_min <- NA
+  data$lat_bin <- NA
+  data$lat_max <- NA
+  data$lat_mid <- NA
+  data$lat_min <- NA
   #=== Assign data ===
   for (i in seq_len(nrow(bins))) {
     vec <- which(
       lat_vals <= bins$max[i] &
         lat_vals >= bins$min[i]
     )
-    occdf$lat_bin[vec] <- bins$bin[i]
-    occdf$lat_max[vec] <- bins$max[i]
-    occdf$lat_mid[vec] <- bins$mid[i]
-    occdf$lat_min[vec] <- bins$min[i]
+    data$lat_bin[vec] <- bins$bin[i]
+    data$lat_max[vec] <- bins$max[i]
+    data$lat_mid[vec] <- bins$mid[i]
+    data$lat_min[vec] <- bins$min[i]
   }
   #=== Boundary bins ===
   if (
@@ -73,7 +73,7 @@ bin_lat <- function(occdf, bins, lat = "lat", boundary = FALSE) {
       any(lat_vals %in% c(bins$max, bins$min))
   ) {
     # Which occurrences fall on boundaries?
-    tmp <- occdf[which(lat_vals %in% c(bins$max, bins$min)), ]
+    tmp <- data[which(lat_vals %in% c(bins$max, bins$min)), ]
     # Reverse direction to ensure alternative bin is assigned
     for (i in rev(seq_len(nrow(bins)))) {
       vec <- which(
@@ -85,7 +85,7 @@ bin_lat <- function(occdf, bins, lat = "lat", boundary = FALSE) {
       tmp$lat_mid[vec] <- bins$mid[i]
       tmp$lat_min[vec] <- bins$min[i]
     }
-    occdf <- rbind.data.frame(occdf, tmp)
+    data <- rbind.data.frame(data, tmp)
   }
   #=== Add warning ===
   if (
@@ -98,5 +98,5 @@ bin_lat <- function(occdf, bins, lat = "lat", boundary = FALSE) {
     ))
   }
   #=== Return data ===
-  return(occdf)
+  return(data)
 }

--- a/R/bin_space.R
+++ b/R/bin_space.R
@@ -3,7 +3,7 @@
 #' A function to assign fossil occurrences (or localities) to spatial
 #' bins/samples using a hexagonal equal-area grid.
 #'
-#' @param occdf \code{dataframe}. A dataframe of the fossil occurrences (or
+#' @param data \code{dataframe}. A dataframe of the fossil occurrences (or
 #' localities) you wish to bin. This dataframe should contain the decimal
 #' degree coordinates of your occurrences, and they should be of
 #' class `numeric`.
@@ -23,8 +23,8 @@
 #' be plotted?
 #'
 #' @return If the `return` argument is set to `FALSE`, a dataframe is
-#' returned of the original input `occdf` with cell information. If `return` is
-#' set to `TRUE`, a list is returned with both the input `occdf` and grid
+#' returned of the original input `data` with cell information. If `return` is
+#' set to `TRUE`, a list is returned with both the input `data` and grid
 #' information and polygons.
 #'
 #' @details This function assigns fossil occurrence data into
@@ -65,23 +65,23 @@
 #' data("reefs")
 #'
 #' # Reduce data for plotting
-#' occdf <- reefs[1:250, ]
+#' data <- reefs[1:250, ]
 #'
 #' # Bin data using a hexagonal equal-area grid
-#' ex1 <- bin_space(occdf = occdf, spacing = 500, plot = TRUE)
+#' ex1 <- bin_space(data = data, spacing = 500, plot = TRUE)
 #'
 #' # Bin data using a hexagonal equal-area grid and sub-grid
-#' ex2 <- bin_space(occdf = occdf, spacing = 1000, sub_grid = 250, plot = TRUE)
+#' ex2 <- bin_space(data = data, spacing = 1000, sub_grid = 250, plot = TRUE)
 #'
 #' # EXAMPLE: rarefy
 #' # Load data
-#' occdf <- tetrapods[1:250, ]
+#' data <- tetrapods[1:250, ]
 #'
 #' # Assign to spatial bin
-#' occdf <- bin_space(occdf = occdf, spacing = 1000, sub_grid = 250)
+#' data <- bin_space(data = data, spacing = 1000, sub_grid = 250)
 #'
 #' # Get unique bins
-#' bins <- unique(occdf$cell_ID)
+#' bins <- unique(data$cell_ID)
 #'
 #' # n reps
 #' n <- 10
@@ -89,8 +89,8 @@
 #' # Rarefy data across sub-grid grid cells
 #' # Returns a list with each element a bin with respective mean genus richness
 #' df <- lapply(bins, function(x) {
-#'   # subset occdf for respective grid cell
-#'   tmp <- occdf[which(occdf$cell_ID == x), ]
+#'   # subset data for respective grid cell
+#'   tmp <- data[which(data$cell_ID == x), ]
 #'
 #'   # Which sub-grid cells are there within this bin?
 #'   sub_bin <- unique(tmp$cell_ID_sub)
@@ -109,7 +109,7 @@
 #' })
 #' @export
 bin_space <- function(
-  occdf,
+  data,
   lng = "lng",
   lat = "lat",
   spacing = 100,
@@ -117,13 +117,13 @@ bin_space <- function(
   return = FALSE,
   plot = FALSE
 ) {
-  ensure_args_are_named(exceptions = "occdf")
+  ensure_args_are_named(exceptions = "data")
 
-  check_data_frame(occdf)
-  check_column_presence(occdf, lat)
-  check_column_presence(occdf, lng)
-  check_range(occdf, lat, -90, 90)
-  check_range(occdf, lng, -180, 180)
+  check_data_frame(data)
+  check_column_presence(data, lat)
+  check_column_presence(data, lng)
+  check_range(data, lat, -90, 90)
+  check_range(data, lng, -180, 180)
 
   check_numeric(spacing, required_length = 1)
   check_numeric(sub_grid, allow_null = TRUE, required_length = 1)
@@ -132,8 +132,8 @@ bin_space <- function(
 
   #=== Set-up ===
   # Convert to sf object and add CRS
-  occdf <- sf::st_as_sf(
-    occdf,
+  data <- sf::st_as_sf(
+    data,
     coords = c(lng, lat),
     remove = FALSE,
     crs = "EPSG:4326"
@@ -150,14 +150,14 @@ bin_space <- function(
   grid$grid <- c("primary")
 
   # Extract cell ID
-  occdf$cell_ID <- h3jsr::point_to_cell(occdf, res = grid$h3_resolution)
+  data$cell_ID <- h3jsr::point_to_cell(data, res = grid$h3_resolution)
 
   # Extract cell centroids
-  occdf$cell_centroid_lng <- sf::st_coordinates(
-    h3jsr::cell_to_point(h3_address = occdf$cell_ID)
+  data$cell_centroid_lng <- sf::st_coordinates(
+    h3jsr::cell_to_point(h3_address = data$cell_ID)
   )[, c("X")]
-  occdf$cell_centroid_lat <- sf::st_coordinates(
-    h3jsr::cell_to_point(h3_address = occdf$cell_ID)
+  data$cell_centroid_lat <- sf::st_coordinates(
+    h3jsr::cell_to_point(h3_address = data$cell_ID)
   )[, c("Y")]
 
   # Sub-grid desired?
@@ -178,21 +178,21 @@ bin_space <- function(
     # Add column grid specification
     s_grid$grid <- c("sub-grid")
     # Extract cell ID
-    occdf$cell_ID_sub <- h3jsr::point_to_cell(occdf, res = s_grid$h3_resolution)
+    data$cell_ID_sub <- h3jsr::point_to_cell(data, res = s_grid$h3_resolution)
 
     # Extract cell centroids
-    occdf$cell_centroid_lng_sub <- sf::st_coordinates(
-      h3jsr::cell_to_point(h3_address = occdf$cell_ID_sub)
+    data$cell_centroid_lng_sub <- sf::st_coordinates(
+      h3jsr::cell_to_point(h3_address = data$cell_ID_sub)
     )[, c("X")]
-    occdf$cell_centroid_lat_sub <- sf::st_coordinates(
-      h3jsr::cell_to_point(h3_address = occdf$cell_ID_sub)
+    data$cell_centroid_lat_sub <- sf::st_coordinates(
+      h3jsr::cell_to_point(h3_address = data$cell_ID_sub)
     )[, c("Y")]
   }
 
   # Drop geometries column
-  occdf <- sf::st_drop_geometry(occdf)
+  data <- sf::st_drop_geometry(data)
   # Format to dataframe
-  occdf <- data.frame(occdf)
+  data <- data.frame(data)
   # Get base grid
   all_cells <- h3jsr::get_res0()
   # Get children at desired resolution
@@ -205,7 +205,7 @@ bin_space <- function(
   base_grid <- h3jsr::cell_to_polygon(input = children, simple = TRUE)
 
   # Get occupied cells
-  primary <- h3jsr::cell_to_polygon(input = occdf$cell_ID, simple = TRUE)
+  primary <- h3jsr::cell_to_polygon(input = data$cell_ID, simple = TRUE)
 
   # Plot data?
   if (plot) {
@@ -226,7 +226,7 @@ bin_space <- function(
     )
     if (!is.null(sub_grid)) {
       secondary <- h3jsr::cell_to_polygon(
-        input = occdf$cell_ID_sub,
+        input = data$cell_ID_sub,
         simple = TRUE
       )
       plot(secondary, col = "#1d91c0", add = TRUE)
@@ -236,11 +236,11 @@ bin_space <- function(
   if (return) {
     if (!is.null(sub_grid)) {
       grid <- rbind.data.frame(grid, s_grid)
-      occdf <- list(occdf, grid, base_grid, primary, secondary)
-      names(occdf) <- c("occdf", "grid_info", "grid_base", "grid", "sub_grid")
+      data <- list(data, grid, base_grid, primary, secondary)
+      names(data) <- c("data", "grid_info", "grid_base", "grid", "sub_grid")
     } else {
-      occdf <- list(occdf, grid, base_grid, primary)
-      names(occdf) <- c("occdf", "grid_info", "grid_base", "grid")
+      data <- list(data, grid, base_grid, primary)
+      names(data) <- c("data", "grid_info", "grid_base", "grid")
     }
   }
   cli::cli_inform(
@@ -253,5 +253,5 @@ bin_space <- function(
       "i" = paste0("\nH3 resolution: ", grid$h3_resolution[1])
     )
   )
-  return(occdf)
+  return(data)
 }

--- a/R/bin_time.R
+++ b/R/bin_time.R
@@ -3,17 +3,17 @@
 #' A function to assign fossil occurrences to specified time bins based on
 #' different approaches commonly applied in palaeobiology.
 #'
-#' @param occdf \code{dataframe}. A dataframe of the fossil occurrences you
+#' @param data \code{dataframe}. A dataframe of the fossil occurrences you
 #'   wish to bin. This dataframe should contain at least two columns with
 #'   `numeric` values: maximum age of occurrence and minimum age of
 #'   occurrence (see `max_ma`, `min_ma`). If required, `numeric` ages can be
 #'   generated from interval names via the
 #'   \code{\link[palaeoverse:look_up]{look_up()}} function.
 #' @param min_ma \code{character}. The name of the column you wish to be
-#'   treated as the minimum age for `occdf` and `bins`, e.g. "min_ma"
+#'   treated as the minimum age for `data` and `bins`, e.g. "min_ma"
 #'   (default).
 #' @param max_ma \code{character}. The name of the column you wish to be
-#'   treated as the maximum age for `occdf` and `bins`, e.g. "max_ma"
+#'   treated as the maximum age for `data` and `bins`, e.g. "max_ma"
 #'   (default).
 #' @param bins \code{dataframe}. A dataframe of the bins that you wish to
 #'   allocate fossil occurrences to such as that returned by
@@ -42,13 +42,13 @@
 #'   function arguments should therefore be scaled to be within these bounds.
 #'
 #' @return For methods "mid", "majority" and "all", a \code{dataframe} of the
-#'   original input `occdf` with the following appended columns is returned:
+#'   original input `data` with the following appended columns is returned:
 #'   occurrence id (`id`), number of bins that the occurrence age range covers
 #'   (`n_bins`), bin assignment (`bin_assignment`), and bin midpoint
 #'   (`bin_midpoint`). In the case of the "majority" method, an additional
 #'   column of the majority percentage overlap (`overlap_percentage`) is also
 #'   appended. For the "random" and "point" method, a \code{list} is returned
-#'   (of length reps) with each element a copy of the `occdf` and appended
+#'   (of length reps) with each element a copy of the `data` and appended
 #'   columns (random: `bin_assignment` and `bin_midpoint`; point:
 #'   `bin_assignment` and `point_estimates`).
 #'
@@ -59,20 +59,20 @@
 #' - Majority: The "majority" method bins an occurrence into the bin which it
 #'   most overlaps with. As part of this implementation, the majority
 #'   percentage overlap of the occurrence is also calculated and returned as
-#'   an additional column in `occdf`. If desired, these percentages can be
+#'   an additional column in `data`. If desired, these percentages can be
 #'   used to further filter an occurrence dataset.
 #' - All: The "all" method bins an occurrence into every bin its age range
 #'   covers. For occurrences with age ranges of more than one bin, the
 #'   occurrence row is duplicated. Each occurrence is assigned an ID in the
-#'   column `occdf$id` so that duplicates can be tracked. Additionally,
-#'   `occdf$n_bins` records the number of bins each occurrence appears within.
+#'   column `data$id` so that duplicates can be tracked. Additionally,
+#'   `data$n_bins` records the number of bins each occurrence appears within.
 #' - Random: The "random" method randomly samples X amount of bins (with
 #'   replacement) from the bins that the fossil occurrence age range covers
 #'   with equal probability regardless of bin length. The `reps` argument
 #'   determines the number of times the sample process is repeated. All
 #'   replications are stored as individual elements within the returned list
 #'   with an appended `bin_assignment` and `bin_midpoint` column to the
-#'   original input `occdf`. If desired, users can easily bind this list using
+#'   original input `data`. If desired, users can easily bind this list using
 #'   \code{do.call(rbind, x)}.
 #' - Point: The "point" method randomly samples X (`reps`) amount of point age
 #'   estimates from the age range of the fossil occurrence. Sampling follows a
@@ -86,7 +86,7 @@
 #'   number of times the sample process is repeated. All replications are
 #'   stored as individual elements within the returned list with an appended
 #'   `bin_assignment` and `point_estimates` column to the original input
-#'   `occdf`. If desired, users can easily bind this list using
+#'   `data`. If desired, users can easily bind this list using
 #'   \code{do.call(rbind, x)}.
 #'
 #' @section Developer(s): Christopher D. Dean & Lewis A. Jones
@@ -94,27 +94,27 @@
 #' @importFrom stats dunif
 #' @examples
 #' #Grab internal tetrapod data
-#' occdf <- tetrapods[1:100, ]
+#' data <- tetrapods[1:100, ]
 #' bins <- time_bins()
 #'
 #' #Assign via midpoint age of fossil occurrence data
-#' ex1 <- bin_time(occdf = occdf, bins = bins, method = "mid")
+#' ex1 <- bin_time(data = data, bins = bins, method = "mid")
 #'
 #' #Assign to all bins that age range covers
-#' ex2 <- bin_time(occdf = occdf, bins = bins, method = "all")
+#' ex2 <- bin_time(data = data, bins = bins, method = "all")
 #'
 #' #Assign via majority overlap based on fossil occurrence age range
-#' ex3 <- bin_time(occdf = occdf, bins = bins, method = "majority")
+#' ex3 <- bin_time(data = data, bins = bins, method = "majority")
 #'
 #' #Assign randomly to overlapping bins based on fossil occurrence age range
-#' ex4 <- bin_time(occdf = occdf, bins = bins, method = "random", reps = 5)
+#' ex4 <- bin_time(data = data, bins = bins, method = "random", reps = 5)
 #'
 #' #Assign point estimates following a normal distribution
-#' ex5 <- bin_time(occdf = occdf, bins = bins, method = "point", reps = 5,
+#' ex5 <- bin_time(data = data, bins = bins, method = "point", reps = 5,
 #'                 fun = dnorm, mean = 0.5, sd = 0.25)
 #' @export
 bin_time <- function(
-  occdf,
+  data,
   min_ma = "min_ma",
   max_ma = "max_ma",
   bins,
@@ -123,22 +123,22 @@ bin_time <- function(
   fun = dunif,
   ...
 ) {
-  ensure_args_are_named(exceptions = "occdf")
+  ensure_args_are_named(exceptions = "data")
 
-  check_data_frame(occdf)
+  check_data_frame(data)
   check_data_frame(bins)
 
-  check_column_presence(occdf, min_ma)
-  check_column_presence(occdf, max_ma)
+  check_column_presence(data, min_ma)
+  check_column_presence(data, max_ma)
   check_column_presence(bins, min_ma)
   check_column_presence(bins, max_ma)
   check_column_presence(bins, "bin")
 
-  occdf_min_ma_vals <- occdf[[min_ma]]
-  occdf_max_ma_vals <- occdf[[max_ma]]
-  check_numeric(occdf_min_ma_vals, allow_na = FALSE, arg = "min_ma")
-  check_numeric(occdf_max_ma_vals, allow_na = FALSE, arg = "max_ma")
-  check_min_lower_than_max(occdf, min_ma, max_ma)
+  data_min_ma_vals <- data[[min_ma]]
+  data_max_ma_vals <- data[[max_ma]]
+  check_numeric(data_min_ma_vals, allow_na = FALSE, arg = "min_ma")
+  check_numeric(data_max_ma_vals, allow_na = FALSE, arg = "max_ma")
+  check_min_lower_than_max(data, min_ma, max_ma)
 
   method <- rlang::arg_match(
     method,
@@ -151,15 +151,15 @@ bin_time <- function(
   bins_max_ma_vals <- bins[[max_ma]]
   check_min_lower_than_max(bins, min_ma, max_ma)
 
-  if (max(occdf_max_ma_vals) > max(bins_max_ma_vals)) {
+  if (max(data_max_ma_vals) > max(bins_max_ma_vals)) {
     cli::cli_abort(
-      "Maximum age of occurrence data ({.val {max(occdf_max_ma_vals)}}) surpasses maximum age of bins ({.val {max(bins_max_ma_vals)}})."
+      "Maximum age of occurrence data ({.val {max(data_max_ma_vals)}}) surpasses maximum age of bins ({.val {max(bins_max_ma_vals)}})."
     )
   }
 
-  if (min(occdf_min_ma_vals) < min(bins_min_ma_vals)) {
+  if (min(data_min_ma_vals) < min(bins_min_ma_vals)) {
     cli::cli_abort(
-      "Minimum age of occurrence data ({.val {min(occdf_min_ma_vals)}}) is less than minimum age of bins ({.val {min(bins_min_ma_vals)}})."
+      "Minimum age of occurrence data ({.val {min(data_min_ma_vals)}}) is less than minimum age of bins ({.val {min(bins_min_ma_vals)}})."
     )
   }
 
@@ -175,14 +175,14 @@ bin_time <- function(
   #=== Reporting Info ===
 
   # Make an empty list that's the length of the occurrence dataframe.
-  bin_list <- vector("list", length = nrow(occdf))
+  bin_list <- vector("list", length = nrow(data))
 
   # For each occurrence, find all the bins that it is present within, and
   # add as elements to that part of the list.
   for (i in seq_len(nrow(bins))) {
     v <- which(
-      occdf[, max_ma, drop = TRUE] > bins[i, min_ma, drop = TRUE] &
-        occdf[, min_ma, drop = TRUE] < bins[i, max_ma, drop = TRUE]
+      data[, max_ma, drop = TRUE] > bins[i, min_ma, drop = TRUE] &
+        data[, min_ma, drop = TRUE] < bins[i, max_ma, drop = TRUE]
     )
     for (j in v) {
       bin_list[[j]] <- append(bin_list[[j]], bins$bin[i])
@@ -190,17 +190,17 @@ bin_time <- function(
   }
 
   # Generate id column for data (this is for tracking duplicate rows).
-  id <- seq_len(nrow(occdf))
-  occdf$id <- id
+  id <- seq_len(nrow(data))
+  data$id <- id
 
   # Generate empty column for recording the number of bins an occurrence
   # appears in, and empty columns for the new bin allocation and midpoint.
-  occdf$n_bins <- NA
-  occdf$bin_assignment <- NA
-  occdf$bin_midpoint <- NA
+  data$n_bins <- NA
+  data$bin_assignment <- NA
+  data$bin_midpoint <- NA
 
   # Assign number of bins per occurrence.
-  occdf$n_bins <- lengths(bin_list)
+  data$n_bins <- lengths(bin_list)
 
   # Generate midpoint ages of bins
   bins$mid_ma <- (bins[, max_ma, drop = TRUE] +
@@ -214,39 +214,39 @@ bin_time <- function(
     # If no mid point is present for occurrence age range, add one in a
     # new column.
     rmcol <- FALSE
-    if (!("mid_ma" %in% colnames(occdf))) {
-      occdf$mid_ma <- (occdf[, max_ma, drop = TRUE] +
-        occdf[, min_ma, drop = TRUE]) /
+    if (!("mid_ma" %in% colnames(data))) {
+      data$mid_ma <- (data[, max_ma, drop = TRUE] +
+        data[, min_ma, drop = TRUE]) /
         2
       rmcol <- TRUE
     }
     # Check if mid_ma equivalent to any bin boundaries
-    if (any(occdf$mid_ma %in% bins$mid_ma)) {
+    if (any(data$mid_ma %in% bins$mid_ma)) {
       warning(paste(
         "One or more occurrences have a midpoint age",
         "equivalent to a bin boundary. Binning skipped for",
         "these occurrences.",
-        "Hint: `which(is.na(occdf$bin_assignment))`."
+        "Hint: `which(is.na(data$bin_assignment))`."
       ))
     }
 
     # Assign bin based on midpoint age of the age range
     for (i in seq_len(nrow(bins))) {
       v <- which(
-        occdf$mid_ma > bins[i, min_ma, drop = TRUE] &
-          occdf$mid_ma < bins[i, max_ma, drop = TRUE]
+        data$mid_ma > bins[i, min_ma, drop = TRUE] &
+          data$mid_ma < bins[i, max_ma, drop = TRUE]
       )
-      occdf$bin_assignment[v] <- bins$bin[i]
-      occdf$bin_midpoint[v] <- bins$mid_ma[i]
+      data$bin_assignment[v] <- bins$bin[i]
+      data$bin_midpoint[v] <- bins$mid_ma[i]
     }
 
     # Remove mid_ma for fossil occurrences (if not already present as input)
     if (rmcol) {
-      occdf <- occdf[, -which(colnames(occdf) == "mid_ma")]
+      data <- data[, -which(colnames(data) == "mid_ma")]
     }
 
     # Return the dataframe and end the function.
-    return(occdf)
+    return(data)
   }
 
   #--- Method 2: Point estimates ---
@@ -272,15 +272,15 @@ bin_time <- function(
       }
     }
     # make occurrence list for filling with reps
-    occ_list <- vector("list", length = nrow(occdf))
+    occ_list <- vector("list", length = nrow(data))
 
     # For each occurrence max/min age, make probability distribution and
     # sample from it. Record that with each occurrence.
-    for (i in seq_len(nrow(occdf))) {
+    for (i in seq_len(nrow(data))) {
       #generate occurrence sequence for sampling
       occ_seq <- seq(
-        from = occdf[i, min_ma, drop = TRUE],
-        to = occdf[i, max_ma, drop = TRUE],
+        from = data[i, min_ma, drop = TRUE],
+        to = data[i, max_ma, drop = TRUE],
         by = 0.001
       )
       #generate x for input probability function
@@ -302,23 +302,23 @@ bin_time <- function(
       }
     }
 
-    occdf$point_estimates <- NA
+    data$point_estimates <- NA
     #drop cols that are not needed
-    occdf <- occdf[, -which(colnames(occdf) == "bin_midpoint")]
+    data <- data[, -which(colnames(data) == "bin_midpoint")]
 
     occ_df_list <- vector("list", length = reps)
 
     #add point estimates to each dataframe
     for (i in seq_len(reps)) {
-      occdf$point_estimates <- do.call(rbind, occ_list)[, i]
+      data$point_estimates <- do.call(rbind, occ_list)[, i]
       for (j in seq_len(nrow(bins))) {
         vec <- which(
-          occdf$point_estimates <= bins[j, max_ma, drop = TRUE] &
-            occdf$point_estimates >= bins[j, min_ma, drop = TRUE]
+          data$point_estimates <= bins[j, max_ma, drop = TRUE] &
+            data$point_estimates >= bins[j, min_ma, drop = TRUE]
         )
-        occdf$bin_assignment[vec] <- bins$bin[j]
+        data$bin_assignment[vec] <- bins$bin[j]
       }
-      occ_df_list[[i]] <- occdf
+      occ_df_list[[i]] <- data
     }
 
     #return list of data
@@ -328,31 +328,31 @@ bin_time <- function(
   #--- Method 3: All ---
   if (method == "all") {
     # Duplicate rows by number of bins.
-    occdf <- occdf[rep(seq_len(dim(occdf)[1]), occdf$n_bins), ]
+    data <- data[rep(seq_len(dim(data)[1]), data$n_bins), ]
 
     # Use id to track unique rows and update bin numbers.
     for (i in id) {
-      id_vec <- which(occdf$id == i)
-      occdf$bin_assignment[id_vec] <- bin_list[[i]]
+      id_vec <- which(data$id == i)
+      data$bin_assignment[id_vec] <- bin_list[[i]]
     }
     # Add bin midpoints to dataframe
     for (i in seq_len(nrow(bins))) {
-      vec <- which(occdf$bin_assignment == bins$bin[i])
-      occdf$bin_midpoint[vec] <- bins$mid_ma[i]
+      vec <- which(data$bin_assignment == bins$bin[i])
+      data$bin_midpoint[vec] <- bins$mid_ma[i]
     }
 
-    if (!inherits(occdf, "tbl")) {
-      rownames(occdf) <- seq_len(nrow(occdf))
+    if (!inherits(data, "tbl")) {
+      rownames(data) <- seq_len(nrow(data))
     }
 
     # Return the dataframe and end the function.
-    return(occdf)
+    return(data)
   }
 
   #--- Method 4: Majority ---
   if (method == "majority") {
     # Setup column for calculating overlap of age range with bin
-    occdf$overlap_percentage <- NA
+    data$overlap_percentage <- NA
 
     # Run across bin list
     for (i in seq_along(bin_list)) {
@@ -361,8 +361,8 @@ bin_time <- function(
 
       # Generate sequence of length 10000 for percentage calculations
       occ_seq <- seq(
-        occdf[i, min_ma, drop = TRUE],
-        occdf[i, max_ma, drop = TRUE],
+        data[i, min_ma, drop = TRUE],
+        data[i, max_ma, drop = TRUE],
         length.out = 10000
       )
 
@@ -378,17 +378,17 @@ bin_time <- function(
       }
 
       # Assign bins, bin midpoints and overlap percentage
-      occdf[i, "bin_assignment"] <- tmpbin$bin[which.max(percentage)]
-      occdf[i, "bin_midpoint"] <- tmpbin$mid_ma[which.max(percentage)]
-      occdf[i, "overlap_percentage"] <- percentage[which.max(percentage)]
+      data[i, "bin_assignment"] <- tmpbin$bin[which.max(percentage)]
+      data[i, "bin_midpoint"] <- tmpbin$mid_ma[which.max(percentage)]
+      data[i, "overlap_percentage"] <- percentage[which.max(percentage)]
     }
-    return(occdf)
+    return(data)
   }
 
   #--- Method 5: Random ---
   if (method == "random") {
     # Generate empty lists for populating
-    occ_list <- vector("list", length = nrow(occdf))
+    occ_list <- vector("list", length = nrow(data))
     occ_df_list <- vector("list", length = reps)
 
     # Randomly sample from the list of bins that occurrence appears in, and
@@ -409,17 +409,17 @@ bin_time <- function(
 
     #add point estimates to each dataframe
     for (i in 1:reps) {
-      occdf$bin_assignment <- do.call(rbind, occ_list)[, i]
-      occdf$bin_midpoint <- bins$mid_ma[
+      data$bin_assignment <- do.call(rbind, occ_list)[, i]
+      data$bin_midpoint <- bins$mid_ma[
         sapply(
-          occdf$bin_assignment,
+          data$bin_assignment,
           function(x) {
             which(bins$bin == x)
           },
           simplify = TRUE
         )
       ]
-      occ_df_list[[i]] <- occdf
+      occ_df_list[[i]] <- data
     }
     return(occ_df_list)
   }

--- a/R/group_apply.R
+++ b/R/group_apply.R
@@ -5,7 +5,7 @@
 #' `data.frame` as input (e.g. `nrow`, `ncol`, `lengths`, `unique`) may also be
 #' used.
 #'
-#' @param occdf \code{dataframe}. A dataframe of fossil occurrences or taxa,
+#' @param data \code{dataframe}. A dataframe of fossil occurrences or taxa,
 #' as relevant to the desired function.
 #' This dataframe must contain the grouping variables and the necessary
 #' variables for the function you wish to call (see function-specific
@@ -15,7 +15,7 @@
 #' one grouping variable will produce an output containing subgroups for each
 #' unique combination of values.
 #' @param fun \code{function}. The function you wish to apply to
-#' `occdf`. See details for compatible functions.
+#' `data`. See details for compatible functions.
 #' @param ... Additional arguments available in the called
 #' function. These arguments may be required for function arguments
 #' without default values, or if you wish to overwrite the default argument
@@ -58,13 +58,13 @@
 #' @examples
 #' # Examples
 #' # Get tetrapods data
-#' occdf <- tetrapods[1:100, ]
+#' data <- tetrapods[1:100, ]
 #' # Remove NA data
-#' occdf <- subset(occdf, !is.na(genus))
+#' data <- subset(data, !is.na(genus))
 #' # Count number of occurrences from each country
-#' ex1 <- group_apply(occdf = occdf, group = "cc", fun = nrow)
+#' ex1 <- group_apply(data = data, group = "cc", fun = nrow)
 #' # Unique genera per collection with group_apply and input arguments
-#' ex2 <- group_apply(occdf = occdf,
+#' ex2 <- group_apply(data = data,
 #'                    group = "collection_no",
 #'                    fun = tax_unique,
 #'                    genus = "genus",
@@ -73,30 +73,30 @@
 #'                    class = "class",
 #'                    resolution = "genus")
 #' # Use multiple variables (number of occurrences per collection and formation)
-#' ex3 <- group_apply(occdf = occdf,
+#' ex3 <- group_apply(data = data,
 #'                    group = c("collection_no", "formation"),
 #'                    fun = nrow)
 #' # Compute counts of occurrences per latitudinal bin
 #' # Set up lat bins
 #' bins <- lat_bins_degrees()
 #' # bin occurrences
-#' occdf <- bin_lat(occdf = occdf, bins = bins)
+#' data <- bin_lat(data = data, bins = bins)
 #' # Calculate number of occurrences per bin
-#' ex4 <- group_apply(occdf = occdf, group = "lat_bin", fun = nrow)
+#' ex4 <- group_apply(data = data, group = "lat_bin", fun = nrow)
 #' @export
-group_apply <- function(occdf, group, fun, ...) {
-  ensure_args_are_named(exceptions = "occdf")
+group_apply <- function(data, group, fun, ...) {
+  ensure_args_are_named(exceptions = "data")
 
-  check_data_frame(occdf)
+  check_data_frame(data)
 
   check_character(group)
   if (length(group) == 0) {
     cli::cli_abort("{.arg group} must specify at least one column.")
   }
-  unknown_cols <- setdiff(group, colnames(occdf))
+  unknown_cols <- setdiff(group, colnames(data))
   if (length(unknown_cols) > 0) {
     cli::cli_abort(
-      "Column{?s} {.val {unknown_cols}} not found in {.arg occdf}."
+      "Column{?s} {.val {unknown_cols}} not found in {.arg data}."
     )
   }
 
@@ -117,8 +117,8 @@ group_apply <- function(occdf, group, fun, ...) {
   }
 
   output_lst <- by(
-    data = occdf,
-    INDICES = occdf[, group, drop = FALSE],
+    data = data,
+    INDICES = data[, group, drop = FALSE],
     FUN = fun,
     ...
   )

--- a/R/look_up.R
+++ b/R/look_up.R
@@ -6,13 +6,13 @@
 #' and numeric ages from the International Commission on Stratigraphy (ICS), or
 #' user-defined intervals, to fossil occurrences.
 #'
-#' @param occdf \code{data.frame}. A dataframe of fossil occurrences or other
+#' @param data \code{data.frame}. A dataframe of fossil occurrences or other
 #' geological data, with columns of class \code{character} specifying the
 #' earliest and the latest possible interval associated with each occurrence.
-#' @param early_interval \code{character}. Name of the column in `occdf` that
+#' @param early_interval \code{character}. Name of the column in `data` that
 #' contains the earliest interval from which the occurrences are from. Defaults
 #'  to "early_interval".
-#' @param late_interval \code{character}. Name of the column in `occdf` that
+#' @param late_interval \code{character}. Name of the column in `data` that
 #' contains the latest interval from which the occurrences are from. Defaults
 #'  to "late_interval".
 #' @param int_key \code{data.frame}. A dataframe linking interval names to
@@ -21,7 +21,7 @@
 #' This dataframe should contain the following named columns containing
 #' `character` values: \cr
 #' \itemize{
-#' \item `interval_name` contains the names to be matched from `occdf` \cr
+#' \item `interval_name` contains the names to be matched from `data` \cr
 #' \item `early_stage` contains the names of the earliest stages
 #' corresponding to the intervals \cr
 #' \item `late_stage` contains the latest stage corresponding to the
@@ -79,33 +79,33 @@
 #' @examples
 #' ## Just use GTS2020 (default):
 #' # create exemplary dataframe
-#' taxdf <- data.frame(name = c("A", "B", "C"),
+#' data <- data.frame(name = c("A", "B", "C"),
 #' early_interval = c("Maastrichtian", "Campanian", "Sinemurian"),
 #' late_interval = c("Maastrichtian", "Campanian", "Bartonian"))
 #' # assign stages and numerical ages
-#' taxdf <- look_up(taxdf)
+#' data <- look_up(data)
 #'
 #' ## Use exemplary int_key
 #' # Get internal reef data
-#' occdf <- reefs
+#' data <- reefs
 #'  # assign stages and numerical ages
-#' occdf <- look_up(occdf,
+#' data <- look_up(data,
 #'                 early_interval = "interval",
 #'                 late_interval = "interval",
 #'                 int_key = interval_key)
 #'
 #' ## Use exemplary int_key and return unassigned
 #' # Get internal tetrapod data
-#' occdf <- tetrapods
+#' data <- tetrapods
 #' # assign stages and numerical ages
-#' occdf <- look_up(occdf, int_key = palaeoverse::interval_key)
+#' data <- look_up(data, int_key = palaeoverse::interval_key)
 #' # return unassigned intervals
-#' unassigned <- look_up(occdf, int_key = palaeoverse::interval_key,
+#' unassigned <- look_up(data, int_key = palaeoverse::interval_key,
 #'                       return_unassigned = TRUE)
 #'
 #' ## Use own key and GTS2012:
 #' # create example data
-#' occdf <- data.frame(
+#' data <- data.frame(
 #'   stage = c("any Permian", "first Permian stage",
 #'             "any Permian", "Roadian"))
 #' # create example key
@@ -114,25 +114,25 @@
 #'   early_stage = c("Asselian", "Asselian"),
 #'   late_stage = c("Changhsingian", "Asselian"))
 #' # assign stages and numerical ages:
-#' occdf <- look_up(occdf,
+#' data <- look_up(data,
 #'                  early_interval = "stage", late_interval = "stage",
 #'                  int_key = interval_key, assign_with_GTS = "GTS2012")
 #'
 #' @export
 look_up <- function(
-  occdf,
+  data,
   early_interval = "early_interval",
   late_interval = "late_interval",
   int_key = FALSE,
   assign_with_GTS = "GTS2020",
   return_unassigned = FALSE
 ) {
-  ensure_args_are_named(exceptions = "occdf")
+  ensure_args_are_named(exceptions = "data")
 
-  check_data_frame(occdf)
+  check_data_frame(data)
 
-  check_column_presence(occdf, early_interval)
-  check_column_presence(occdf, late_interval)
+  check_column_presence(data, early_interval)
+  check_column_presence(data, late_interval)
 
   # int_key checks
   if (!is.data.frame(int_key)) {
@@ -165,8 +165,8 @@ look_up <- function(
   #=== Preparation ===
 
   # save early and late int columns for easier handling
-  early <- occdf[, early_interval, drop = TRUE]
-  late <- occdf[, late_interval, drop = TRUE]
+  early <- data[, early_interval, drop = TRUE]
+  late <- data[, late_interval, drop = TRUE]
 
   # if there are missing values in `late`, fill them in from `early`
   replace_pattern <- c("", " ")
@@ -186,19 +186,19 @@ look_up <- function(
   }
 
   # add columns to output data frame
-  occdf$early_stage <- rep(NA_character_, nrow(occdf))
-  occdf$late_stage <- rep(NA_character_, nrow(occdf))
+  data$early_stage <- rep(NA_character_, nrow(data))
+  data$late_stage <- rep(NA_character_, nrow(data))
   if ("max_ma" %in% colnames(int_key) || is.character(assign_with_GTS)) {
-    occdf$interval_max_ma <- rep(NA_real_, nrow(occdf))
+    data$interval_max_ma <- rep(NA_real_, nrow(data))
   }
   if (
     ("max_ma" %in% colnames(int_key) && "min_ma" %in% colnames(int_key)) ||
       is.character(assign_with_GTS)
   ) {
-    occdf$interval_mid_ma <- rep(NA_real_, nrow(occdf))
+    data$interval_mid_ma <- rep(NA_real_, nrow(data))
   }
   if ("min_ma" %in% colnames(int_key) || is.character(assign_with_GTS)) {
-    occdf$interval_min_ma <- rep(NA_real_, nrow(occdf))
+    data$interval_min_ma <- rep(NA_real_, nrow(data))
   }
 
   ## early stages unique entries
@@ -222,11 +222,11 @@ look_up <- function(
     # loop through assignable intervals and assign early stages
     for (i in seq_len(length(assign1))) {
       # early stage
-      occdf$early_stage[early == assign1[i]] <-
+      data$early_stage[early == assign1[i]] <-
         int_key$early_stage[int_key$interval_name == assign1[i]]
       # max_ma
       if ("max_ma" %in% colnames(int_key)) {
-        occdf$interval_max_ma[early == assign1[i]] <-
+        data$interval_max_ma[early == assign1[i]] <-
           int_key$max_ma[int_key$interval_name == assign1[i]]
       }
     }
@@ -244,11 +244,11 @@ look_up <- function(
     # loop through assignable intervals and assign late stages
     for (i in seq_len(length(assign2))) {
       #late stage
-      occdf$late_stage[late == assign2[i]] <-
+      data$late_stage[late == assign2[i]] <-
         int_key$late_stage[int_key$interval_name == assign2[i]]
       # min_ma
       if ("min_ma" %in% colnames(int_key)) {
-        occdf$interval_min_ma[late == assign2[i]] <-
+        data$interval_min_ma[late == assign2[i]] <-
           int_key$min_ma[int_key$interval_name == assign2[i]]
       }
     }
@@ -319,9 +319,9 @@ look_up <- function(
 
     # assign early stages to occurrences
     for (i in seq_len(length(assign_gts1))) {
-      occdf$early_stage[
+      data$early_stage[
         early == assign_gts1[i] &
-          is.na(occdf$early_stage)
+          is.na(data$early_stage)
       ] <-
         gts$interval_name[
           gts$max_ma == assigned_max_ma_gts[i] &
@@ -361,9 +361,9 @@ look_up <- function(
     # assign late stages to occurrences
     for (i in seq_len(length(assign_gts2))) {
       # stage
-      occdf$late_stage[
+      data$late_stage[
         late == assign_gts2[i] &
-          is.na(occdf$late_stage)
+          is.na(data$late_stage)
       ] <-
         gts$interval_name[
           gts$min_ma == assigned_min_ma_gts[i] &
@@ -373,8 +373,8 @@ look_up <- function(
 
     # add max_ma and min_ma based on GTS
     # max_ma
-    if ("interval_max_ma" %in% colnames(occdf)) {
-      stage_unique <- unique(occdf$early_stage)
+    if ("interval_max_ma" %in% colnames(data)) {
+      stage_unique <- unique(data$early_stage)
       # find assignable intervals
       assign_age_ind <- vapply(
         stage_unique,
@@ -394,16 +394,16 @@ look_up <- function(
       )
       # assign max age
       for (i in seq_len(length(assign_age))) {
-        occdf$interval_max_ma[
-          occdf$early_stage == assign_age[i] &
-            is.na(occdf$interval_max_ma)
+        data$interval_max_ma[
+          data$early_stage == assign_age[i] &
+            is.na(data$interval_max_ma)
         ] <-
           assigned_max_ma_gts[i]
       }
     }
     # min_ma
-    if ("interval_min_ma" %in% colnames(occdf)) {
-      stage_unique <- unique(occdf$late_stage)
+    if ("interval_min_ma" %in% colnames(data)) {
+      stage_unique <- unique(data$late_stage)
       # find assignable intervals
       assign_age_ind <- vapply(
         stage_unique,
@@ -423,9 +423,9 @@ look_up <- function(
       )
       # assign min age
       for (i in seq_len(length(assign_age))) {
-        occdf$interval_min_ma[
-          occdf$late_stage == assign_age[i] &
-            is.na(occdf$interval_min_ma)
+        data$interval_min_ma[
+          data$late_stage == assign_age[i] &
+            is.na(data$interval_min_ma)
         ] <-
           assigned_min_ma_gts[i]
       }
@@ -436,25 +436,25 @@ look_up <- function(
 
   if (
     "interval_max_ma" %in%
-      colnames(occdf) &&
-      "interval_min_ma" %in% colnames(occdf)
+      colnames(data) &&
+      "interval_min_ma" %in% colnames(data)
   ) {
-    occdf$interval_mid_ma <- (occdf$interval_max_ma + occdf$interval_min_ma) / 2
+    data$interval_mid_ma <- (data$interval_max_ma + data$interval_min_ma) / 2
   }
 
   #=== get names of intervals which could not be assigned ===
 
   unassigned <- sort(unique(c(
-    occdf[
+    data[
       which(
-        is.na(occdf$early_stage)
+        is.na(data$early_stage)
       ),
       early_interval,
       drop = TRUE
     ],
-    occdf[
+    data[
       which(
-        is.na(occdf$late_stage)
+        is.na(data$late_stage)
       ),
       late_interval,
       drop = TRUE
@@ -482,5 +482,5 @@ look_up <- function(
     }
   }
 
-  if (!return_unassigned) occdf
+  if (!return_unassigned) data
 }

--- a/R/palaeorotate.R
+++ b/R/palaeorotate.R
@@ -6,8 +6,8 @@
 #' palaeocoordinates based on its current geographic position and age
 #' estimate.
 #'
-#' @param occdf \code{data.frame}. Fossil occurrences to be
-#'   palaeogeographically reconstructed. \code{occdf} should contain columns
+#' @param data \code{data.frame}. Fossil occurrences to be
+#'   palaeogeographically reconstructed. \code{data} should contain columns
 #'   with longitudinal and latitudinal coordinates, as well as age estimates.
 #'   The age of rotation should be supplied in millions of years before
 #'   present.
@@ -130,18 +130,18 @@
 #' @examples
 #' \dontrun{
 #' #Generic example with a few occurrences
-#' occdf <- data.frame(lng = c(2, -103, -66),
+#' data <- data.frame(lng = c(2, -103, -66),
 #'                 lat = c(46, 35, -7),
 #'                 age = c(88, 125, 200))
 #'
 #' #Calculate palaeocoordinates using reconstruction files
-#' ex1 <- palaeorotate(occdf = occdf, method = "grid")
+#' ex1 <- palaeorotate(data = data, method = "grid")
 #'
 #' #Calculate palaeocoordinates using the GPlates API
-#' ex2 <- palaeorotate(occdf = occdf, method = "point")
+#' ex2 <- palaeorotate(data = data, method = "point")
 #'
 #' #Calculate uncertainity in palaeocoordinates from models
-#' ex3 <- palaeorotate(occdf = occdf,
+#' ex3 <- palaeorotate(data = data,
 #'                     method = "grid",
 #'                     model = c("MERDITH2021",
 #'                               "GOLONKA",
@@ -157,10 +157,10 @@
 #' tetrapods$age <- (tetrapods$max_ma + tetrapods$min_ma)/2
 #'
 #' #Rotate the data
-#' ex3 <- palaeorotate(occdf = tetrapods)
+#' ex3 <- palaeorotate(data = tetrapods)
 #'
 #' #Calculate uncertainity in palaeocoordinates from models
-#' ex4 <- palaeorotate(occdf = tetrapods,
+#' ex4 <- palaeorotate(data = tetrapods,
 #'                     model = c("MERDITH2021",
 #'                               "GOLONKA",
 #'                               "PALEOMAP"),
@@ -168,7 +168,7 @@
 #' }
 #' @export
 palaeorotate <- function(
-  occdf,
+  data,
   lng = "lng",
   lat = "lat",
   age = "age",
@@ -177,22 +177,22 @@ palaeorotate <- function(
   uncertainty = TRUE,
   round = 3
 ) {
-  ensure_args_are_named(exceptions = "occdf")
+  ensure_args_are_named(exceptions = "data")
 
   # This is used in error messages to report in which function call the error occurred. We save it
   # here so that we don't need to use e.g. `rlang::caller_env(4)` when running `cli::cli_abort()`
   # in `tryCatch()`.
   caller_env <- rlang::current_env()
 
-  check_data_frame(occdf)
+  check_data_frame(data)
 
-  check_column_presence(occdf, lng)
-  check_column_presence(occdf, lat)
-  check_column_presence(occdf, age)
+  check_column_presence(data, lng)
+  check_column_presence(data, lat)
+  check_column_presence(data, age)
 
-  check_range(occdf, lat, -90, 90)
-  check_range(occdf, lng, -180, 180)
-  check_range(occdf, age, 0, Inf)
+  check_range(data, lat, -90, 90)
+  check_range(data, lng, -180, 180)
+  check_range(data, age, 0, Inf)
 
   rlang::check_string(method)
   method <- rlang::arg_match(method, values = c("point", "grid"))
@@ -234,19 +234,19 @@ palaeorotate <- function(
   # If only one model selected, add column of model name and set uncertainty
   # to FALSE
   if (length(model) == 1) {
-    occdf$rot_model <- model
+    data$rot_model <- model
     uncertainty <- FALSE
   }
 
   # Should coordinates be rounded off?
   if (!is.null(round)) {
-    occdf[, c(lng, lat, age)] <- round(
-      occdf[, c(lng, lat, age)],
+    data[, c(lng, lat, age)] <- round(
+      data[, c(lng, lat, age)],
       digits = round
     )
   }
   # Unique localities for rotating
-  coords <- unique(occdf[, c(lng, lat, age)])
+  coords <- unique(data[, c(lng, lat, age)])
   # Add columns for populating
   uni_ages <- unique(coords[, age, drop = TRUE])
 
@@ -299,12 +299,12 @@ palaeorotate <- function(
       }
     }
     # Calculate rotation ages for data
-    occdf$rot_age <- round(occdf[, age, drop = TRUE], digits = 0)
+    data$rot_age <- round(data[, age, drop = TRUE], digits = 0)
 
     # Set-up
     # Convert to sf object and add CRS
-    occdf_sf <- st_as_sf(
-      x = occdf,
+    data_sf <- st_as_sf(
+      x = data,
       coords = c(lng, lat),
       remove = FALSE,
       crs = "EPSG:4326"
@@ -312,7 +312,7 @@ palaeorotate <- function(
 
     # Match points with cells
     h3 <- point_to_cell(
-      input = occdf_sf,
+      input = data_sf,
       res = 3, # Grid resolution
       simple = TRUE
     )
@@ -321,7 +321,7 @@ palaeorotate <- function(
     # Create df
     xy <- data.frame(h3 = h3, rot_lng = xy[, 1], rot_lat = xy[, 2])
     # Bind rotation coordinates
-    occdf <- cbind.data.frame(occdf, xy)
+    data <- cbind.data.frame(data, xy)
     # Assign model coordinates
     for (m in model) {
       # Load reconstruction files
@@ -330,14 +330,14 @@ palaeorotate <- function(
       colnames(prm)[which(colnames(prm) %in% c("lng", "lat"))] <-
         c("lng_0", "lat_0")
       # Extract coordinates
-      row_match <- match(x = occdf$h3, table = prm$h3)
+      row_match <- match(x = data$h3, table = prm$h3)
 
-      p_lng <- sapply(seq_len(nrow(occdf)), function(i) {
-        prm[row_match[i], c(paste0("lng_", occdf$rot_age[i]))]
+      p_lng <- sapply(seq_len(nrow(data)), function(i) {
+        prm[row_match[i], c(paste0("lng_", data$rot_age[i]))]
       })
 
-      p_lat <- sapply(seq_len(nrow(occdf)), function(i) {
-        prm[row_match[i], c(paste0("lat_", occdf$rot_age[i]))]
+      p_lat <- sapply(seq_len(nrow(data)), function(i) {
+        prm[row_match[i], c(paste0("lat_", data$rot_age[i]))]
       })
 
       # Replace NULL values
@@ -348,15 +348,15 @@ palaeorotate <- function(
       }
       # Assign to columns
       if (length(model) > 1) {
-        occdf[, paste0("p_lng_", m)] <- unlist(p_lng)
-        occdf[, paste0("p_lat_", m)] <- unlist(p_lat)
+        data[, paste0("p_lng_", m)] <- unlist(p_lng)
+        data[, paste0("p_lat_", m)] <- unlist(p_lat)
       } else {
-        occdf$p_lng <- unlist(p_lng)
-        occdf$p_lat <- unlist(p_lat)
+        data$p_lng <- unlist(p_lng)
+        data$p_lat <- unlist(p_lat)
       }
     }
     # Drop h3 column
-    occdf <- occdf[, -which(colnames(occdf) == "h3")]
+    data <- data[, -which(colnames(data) == "h3")]
   }
 
   # Point rotations ---------------------------------------------------------
@@ -413,12 +413,12 @@ palaeorotate <- function(
       "_",
       coords[, age, drop = TRUE]
     )
-    occdf$match <- paste0(
-      occdf[, lng, drop = TRUE],
+    data$match <- paste0(
+      data[, lng, drop = TRUE],
       "_",
-      occdf[, lat, drop = TRUE],
+      data[, lat, drop = TRUE],
       "_",
-      occdf[, age, drop = TRUE]
+      data[, age, drop = TRUE]
     )
     # Prepare points query
     # Split dataframe by age
@@ -497,12 +497,12 @@ palaeorotate <- function(
     # Match data
     for (i in seq_along(multi_model)) {
       x <- multi_model[[i]]
-      mch <- match(x = occdf$match, table = x$match)
-      occdf[, colnames(x)] <- x[mch, ]
+      mch <- match(x = data$match, table = x$match)
+      data[, colnames(x)] <- x[mch, ]
     }
 
     # Drop match column
-    occdf <- occdf[, -which(colnames(occdf) == "match"), drop = TRUE]
+    data <- data[, -which(colnames(data) == "match"), drop = TRUE]
   }
 
   # Uncertainty calculation -------------------------------------------------
@@ -510,8 +510,8 @@ palaeorotate <- function(
     # Calculate uncertainty (range)
     lng_nme <- paste0("p_lng_", model)
     lat_nme <- paste0("p_lat_", model)
-    uncertain_lng <- occdf[, lng_nme, drop = TRUE]
-    uncertain_lat <- occdf[, lat_nme, drop = TRUE]
+    uncertain_lng <- data[, lng_nme, drop = TRUE]
+    uncertain_lat <- data[, lat_nme, drop = TRUE]
 
     # Calculate palaeolatitudinal range
     range_p_lat <- vector("numeric")
@@ -549,7 +549,7 @@ palaeorotate <- function(
       }
     }
     # Bind data
-    occdf <- cbind.data.frame(occdf, range_p_lat, max_dist)
+    data <- cbind.data.frame(data, range_p_lat, max_dist)
   }
 
   # Wrap up -----------------------------------------------------------------
@@ -558,7 +558,7 @@ palaeorotate <- function(
   } else {
     cnames <- c("p_lng", "p_lat")
   }
-  if (anyNA(occdf[, cnames])) {
+  if (anyNA(data[, cnames])) {
     cli::cli_warn(
       c(
         "Palaeocoordinates could not be reconstructed for all points.",
@@ -567,5 +567,5 @@ palaeorotate <- function(
     )
   }
   # Return data
-  return(occdf)
+  return(data)
 }

--- a/R/tax_certainty.R
+++ b/R/tax_certainty.R
@@ -5,7 +5,7 @@
 #' denoting the certainty of taxonomic identifications (see Details for
 #' screening values).
 #'
-#' @param taxdf \code{data.frame}. A \code{data.frame} with a named column
+#' @param data \code{data.frame}. A \code{data.frame} with a named column
 #'   containing the taxonomic names to be checked.
 #' @param name \code{character}. The column name of the taxonomic names you
 #'   wish to check (e.g. "identified_name").
@@ -20,12 +20,12 @@
 #'   "certain" status (default: 1), while the second denotes "uncertain"
 #'   status (default: 0).
 #' @param append \code{logical}. If \code{TRUE} (default), the returned object
-#'   is a \code{data.frame} consisting of the input \code{taxdf} with a column
+#'   is a \code{data.frame} consisting of the input \code{data} with a column
 #'   denoting the taxonomic "certainty" appended. If \code{FALSE}, a two-column
 #'   \code{data.frame} containing the input `name` and the taxonomic
 #'   identification certainty status is returned.
 #'
-#' @return When `append` is \code{TRUE}, the input \code{taxdf} with an
+#' @return When `append` is \code{TRUE}, the input \code{data} with an
 #'   appended "certainty" column classifying each taxon (default). When
 #'   \code{append} is `FALSE`, a two-column \code{data.frame} with input `name`
 #'   and 'certainty' column classifying each taxon.
@@ -81,31 +81,31 @@
 #' @examples
 #' # Get internal data
 #' data(tetrapods)
-#' occdf <- tetrapods[1:100, ]
+#' data <- tetrapods[1:100, ]
 #' # Summarise taxonomic certainty
-#' certainty <- tax_certainty(taxdf = occdf, name = "identified_name",
+#' certainty <- tax_certainty(data = data, name = "identified_name",
 #'                            append = FALSE)
 #' # Append uncertainty to dataframe
-#' certainty <- tax_certainty(taxdf = occdf, name = "identified_name",
+#' certainty <- tax_certainty(data = data, name = "identified_name",
 #'                            certainty = c("certain", "uncertain"),
 #'                            append = TRUE)
 #' # Turn off subspecies- and species-level screening terms (genus-level data)
-#' certainty <- tax_certainty(taxdf = occdf, name = "identified_name",
+#' certainty <- tax_certainty(data = data, name = "identified_name",
 #'                            terms = list(subspecies = NULL, species = NULL),
 #'                            certainty = c("certain", "uncertain"),
 #'                            append = FALSE)
 #' @export
 tax_certainty <- function(
-  taxdf,
+  data,
   name,
   terms = NULL,
   certainty = c(1, 0),
   append = TRUE
 ) {
-  ensure_args_are_named(exceptions = "taxdf")
-  check_data_frame(taxdf)
-  check_column_presence(taxdf, name)
-  check_class(taxdf, name, "character")
+  ensure_args_are_named(exceptions = "data")
+  check_data_frame(data)
+  check_column_presence(data, name)
+  check_class(data, name, "character")
 
   if (!is.null(terms) && !is.list(terms)) {
     cli::cli_abort(
@@ -114,13 +114,13 @@ tax_certainty <- function(
   }
   rlang::check_bool(append)
 
-  # Create temporary taxdf column to not replace original values
-  taxdf$certainty <- taxdf[[name]]
+  # Create temporary data column to not replace original values
+  data$certainty <- data[[name]]
   # Replace empty rows with NA
-  taxdf$certainty <- gsub(
+  data$certainty <- gsub(
     pattern = "^$|^\\s+$",
     replacement = NA_character_,
-    x = taxdf$certainty
+    x = data$certainty
   )
   # Terms to screen for
   screen <- list(
@@ -150,11 +150,11 @@ tax_certainty <- function(
   screen <- screen[!unlist(lapply(screen, is.null))]
   # Identify taxonomic certainty
   matches <- lapply(screen, function(x) {
-    sapply(x, grepl, taxdf$certainty, ignore.case = TRUE, perl = TRUE)
+    sapply(x, grepl, data$certainty, ignore.case = TRUE, perl = TRUE)
   })
   matches <- do.call(cbind, matches)
   # Explicitly test NA
-  matches <- cbind(matches, is.na = is.na(taxdf$certainty))
+  matches <- cbind(matches, is.na = is.na(data$certainty))
   # Calculate row sums (1 (or more) = match/uncertain, 0 = no match/certain)
   matches <- rowSums(matches)
   # Match user definitions
@@ -165,10 +165,10 @@ tax_certainty <- function(
   # Extract certainty
   classif <- certainty[matches]
   # Add certainty
-  taxdf$certainty <- classif
+  data$certainty <- classif
   # Extract only names and certainty
   if (!append) {
-    taxdf <- taxdf[, c(name, "certainty")]
+    data <- data[, c(name, "certainty")]
   }
-  return(taxdf)
+  return(data)
 }

--- a/R/tax_check.R
+++ b/R/tax_check.R
@@ -4,7 +4,7 @@
 #' taxon. Spelling variations are checked within alphabetical groups (default),
 #' or within higher taxonomic groups if provided.
 #'
-#' @param taxdf \code{data.frame}. A dataframe with named columns containing
+#' @param data \code{data.frame}. A dataframe with named columns containing
 #' taxon names (e.g. "species", "genus"). An optional column
 #' containing the groups (e.g. "family", "order") which taxon names
 #' belong to may also be provided (see `group` for details).
@@ -13,7 +13,7 @@
 #' @param name \code{character}. The column name of the taxon names you wish
 #' to check (e.g. "genus").
 #' @param group \code{character}. The column name of the higher taxonomic
-#' assignments in `taxdf` you wish to group by. If `NULL` (default), name
+#' assignments in `data` you wish to group by. If `NULL` (default), name
 #' comparison will be conducted within alphabetical groups.
 #' @param dis \code{numeric}. The dissimilarity threshold: a value greater than
 #' 0 (completely dissimilar), and less than 1 (completely similar).
@@ -76,45 +76,45 @@
 #' # load occurrence data
 #' data("tetrapods")
 #' # Check taxon names alphabetically
-#' ex1 <- tax_check(taxdf = tetrapods, name = "genus", dis = 0.1)
+#' ex1 <- tax_check(data = tetrapods, name = "genus", dis = 0.1)
 #' # Check taxon names by group
-#' ex2 <- tax_check(taxdf = tetrapods, name = "genus",
+#' ex2 <- tax_check(data = tetrapods, name = "genus",
 #'                  group = "family", dis = 0.1)
 #' }
 #' @export
 tax_check <- function(
-  taxdf,
+  data,
   name = "genus",
   group = NULL,
   dis = 0.05,
   start = 1,
   verbose = TRUE
 ) {
-  ensure_args_are_named(exceptions = "taxdf")
+  ensure_args_are_named(exceptions = "data")
 
   # ARGUMENT CHECKS --------------------------------------------------------- #
 
-  check_data_frame(taxdf)
-  check_column_presence(taxdf, name)
+  check_data_frame(data)
+  check_column_presence(data, name)
 
   # Replace missing values with NA
-  taxdf[grep("^$|^\\s+$", taxdf[, name, drop = TRUE]), name] <- NA
+  data[grep("^$|^\\s+$", data[, name, drop = TRUE]), name] <- NA
 
-  check_class(taxdf, name, "character")
-  if (all(is.na(taxdf[, name, drop = TRUE]))) {
+  check_class(data, name, "character")
+  if (all(is.na(data[, name, drop = TRUE]))) {
     cli::cli_abort(
-      "Column {.val {name}} in {.arg taxdf} must have at least one entry that is not NA or empty."
+      "Column {.val {name}} in {.arg data} must have at least one entry that is not NA or empty."
     )
   }
 
   # groups: If not NULL, a 1L character vector denoting a character column
-  # in taxdf
+  # in data
   if (!is.null(group)) {
-    check_column_presence(taxdf, group)
-    check_class(taxdf, group, "character")
-    group <- gsub("^$|^\\s+$", NA, taxdf[, group, drop = TRUE])
+    check_column_presence(data, group)
+    check_class(data, group, "character")
+    group <- gsub("^$|^\\s+$", NA, data[, group, drop = TRUE])
   } else {
-    group <- substring(taxdf[, name, drop = TRUE], 1, 1)
+    group <- substring(data[, name, drop = TRUE], 1, 1)
   }
 
   # dis: a 1L numeric > 0 and < 1
@@ -134,7 +134,7 @@ tax_check <- function(
     gp <- NULL
   }
 
-  nm <- unique(grep("[^[:alpha:] ]", taxdf[, name, drop = TRUE], value = TRUE))
+  nm <- unique(grep("[^[:alpha:] ]", data[, name, drop = TRUE], value = TRUE))
   if (length(nm) != 0) {
     cli::cli_warn("Non-letter characters present in the taxon names.")
   } else {
@@ -144,21 +144,21 @@ tax_check <- function(
   # FORMAT INPUT DATA ------------------------------------------------------- #
 
   # names data.frame, drop missing names, fill missing groups alphabetically
-  taxdf <- taxdf2 <- data.frame(
+  data <- data2 <- data.frame(
     group = group,
-    name = taxdf[, name, drop = TRUE]
+    name = data[, name, drop = TRUE]
   )
-  taxdf <- taxdf[!duplicated(taxdf), , drop = FALSE]
-  taxdf <- taxdf[!is.na(taxdf[, "name", drop = TRUE]), , drop = FALSE]
-  no_group <- which(is.na(taxdf[, "group", drop = TRUE]))
-  taxdf[no_group, "group"] <- substring(taxdf[no_group, "name"], 1, 1)
+  data <- data[!duplicated(data), , drop = FALSE]
+  data <- data[!is.na(data[, "name", drop = TRUE]), , drop = FALSE]
+  no_group <- which(is.na(data[, "group", drop = TRUE]))
+  data[no_group, "group"] <- substring(data[no_group, "name"], 1, 1)
 
   # RUN GROUPWISE COMPARISONS ----------------------------------------------- #
 
   # apply the comparison procedure group wise
-  sp <- lapply(unique(taxdf[, "group", drop = TRUE]), function(y) {
+  sp <- lapply(unique(data[, "group", drop = TRUE]), function(y) {
     # all taxon names which belong to group y
-    ob <- taxdf[taxdf[, "group", drop = TRUE] == y, "name"]
+    ob <- data[data[, "group", drop = TRUE] == y, "name"]
 
     # if there is are not multiple names in the group, skip
     if (length(ob) < 2) {
@@ -211,16 +211,16 @@ tax_check <- function(
   # format initial results data.frame from list
   err <- sp[!unlist(lapply(sp, is.null))]
   err <- as.data.frame(do.call(rbind, err))
-  err$f1 <- as.vector(table(taxdf2[, "name"])[match(
+  err$f1 <- as.vector(table(data2[, "name"])[match(
     err$V1,
     names(table(
-      taxdf2[, "name"]
+      data2[, "name"]
     ))
   )])
-  err$f2 <- as.vector(table(taxdf2[, "name"])[match(
+  err$f2 <- as.vector(table(data2[, "name"])[match(
     err$V2,
     names(table(
-      taxdf2[, "name"]
+      data2[, "name"]
     ))
   )])
 

--- a/R/tax_expand_lat.R
+++ b/R/tax_expand_lat.R
@@ -9,7 +9,7 @@
 #' where the row representing a taxon must be replicated for each latitudinal
 #' bin through which the taxon ranges.
 #'
-#' @param taxdf \code{dataframe}. A dataframe of taxa (such as the
+#' @param data \code{dataframe}. A dataframe of taxa (such as the
 #' output of the 'lat' method in \code{\link{tax_range_space}}) with columns
 #' containing latitudinal range data (maximum and minimum latitude). Column
 #' names are assumed to be "max_lat" and "min_lat", but may be updated via the
@@ -37,35 +37,35 @@
 #' @export
 #' @examples
 #' bins <- lat_bins_degrees()
-#' taxdf <- data.frame(name = c("A", "B", "C"),
+#' data <- data.frame(name = c("A", "B", "C"),
 #'                     max_lat = c(60, 20, -10),
 #'                     min_lat = c(20, -40, -60))
-#' ex <- tax_expand_lat(taxdf = taxdf,
+#' ex <- tax_expand_lat(data = data,
 #'                      bins = bins,
 #'                      max_lat = "max_lat",
 #'                      min_lat = "min_lat")
 tax_expand_lat <- function(
-  taxdf,
+  data,
   bins,
   max_lat = "max_lat",
   min_lat = "min_lat"
 ) {
-  ensure_args_are_named(exceptions = "taxdf")
+  ensure_args_are_named(exceptions = "data")
 
-  check_data_frame(taxdf)
+  check_data_frame(data)
   check_data_frame(bins)
 
   check_column_presence(bins, "bin")
   check_column_presence(bins, "max")
   check_column_presence(bins, "min")
-  check_column_presence(taxdf, max_lat)
-  check_column_presence(taxdf, min_lat)
+  check_column_presence(data, max_lat)
+  check_column_presence(data, min_lat)
 
-  check_range(taxdf, min_lat, -90, 90)
-  check_range(taxdf, max_lat, -90, 90)
+  check_range(data, min_lat, -90, 90)
+  check_range(data, max_lat, -90, 90)
 
   rows_with_max_lat_smaller_than_min_lat <- which(
-    taxdf[, max_lat, drop = TRUE] < taxdf[, min_lat, drop = TRUE]
+    data[, max_lat, drop = TRUE] < data[, min_lat, drop = TRUE]
   )
   if (length(rows_with_max_lat_smaller_than_min_lat) > 0) {
     truncated <- if (length(rows_with_max_lat_smaller_than_min_lat) > 5) {
@@ -85,15 +85,15 @@ tax_expand_lat <- function(
     )
   }
 
-  if (anyDuplicated(taxdf) > 0) {
-    cli::cli_abort("{.arg taxdf} must not have duplicated rows.")
+  if (anyDuplicated(data) > 0) {
+    cli::cli_abort("{.arg data} must not have duplicated rows.")
   }
 
   # Replicate taxon rows for each lat bin they span
   dat_list <- lapply(seq_len(nrow(bins)), function(i) {
-    int_tax <- taxdf[
-      taxdf[, min_lat, drop = TRUE] < bins$max[i] &
-        taxdf[, max_lat, drop = TRUE] > bins$min[i],
+    int_tax <- data[
+      data[, min_lat, drop = TRUE] < bins$max[i] &
+        data[, max_lat, drop = TRUE] > bins$min[i],
     ]
     if (nrow(int_tax) == 0) {
       return(NULL)

--- a/R/tax_expand_time.R
+++ b/R/tax_expand_time.R
@@ -8,7 +8,7 @@
 #' the row representing a taxon must be replicated for each interval through
 #' which the taxon persisted.
 #'
-#' @param taxdf \code{dataframe}. A dataframe of taxa (such as that
+#' @param data \code{dataframe}. A dataframe of taxa (such as that
 #'   produced by \code{\link{tax_range_time}}) with columns for the maximum and
 #'   minimum ages (FADs and LADs). Each row should represent a unique taxon.
 #'   Additional columns may be included (e.g. taxon names, additional taxonomy,
@@ -47,15 +47,15 @@
 #'   Lewis A. Jones
 #' @export
 #' @examples
-#' taxdf <- data.frame(name = c("A", "B", "C"),
+#' data <- data.frame(name = c("A", "B", "C"),
 #'                     max_ma = c(150, 60, 30),
 #'                     min_ma = c(110, 20, 0))
-#' ex <- tax_expand_time(taxdf)
+#' ex <- tax_expand_time(data)
 #'
 #' bins <- time_bins(scale = "GTS2012", rank = "stage")
-#' ex2 <- tax_expand_time(taxdf, bins = bins)
+#' ex2 <- tax_expand_time(data, bins = bins)
 tax_expand_time <- function(
-  taxdf,
+  data,
   max_ma = "max_ma",
   min_ma = "min_ma",
   bins = NULL,
@@ -63,14 +63,14 @@ tax_expand_time <- function(
   rank = "stage",
   ext_orig = TRUE
 ) {
-  ensure_args_are_named(exceptions = "taxdf")
-  check_data_frame(taxdf)
+  ensure_args_are_named(exceptions = "data")
+  check_data_frame(data)
 
-  check_column_presence(taxdf, max_ma)
-  check_column_presence(taxdf, min_ma)
+  check_column_presence(data, max_ma)
+  check_column_presence(data, min_ma)
 
-  check_range(taxdf, min_ma, 0, Inf)
-  check_range(taxdf, max_ma, 0, Inf)
+  check_range(data, min_ma, 0, Inf)
+  check_range(data, max_ma, 0, Inf)
 
   rlang::check_bool(ext_orig)
 
@@ -89,21 +89,21 @@ tax_expand_time <- function(
     check_column_presence(bins, "min_ma")
   }
 
-  check_min_lower_than_max(taxdf, min_ma, max_ma)
+  check_min_lower_than_max(data, min_ma, max_ma)
 
-  if (anyDuplicated(taxdf) > 0) {
-    cli::cli_abort("{.arg taxdf} must not have duplicated rows.")
+  if (anyDuplicated(data) > 0) {
+    cli::cli_abort("{.arg data} must not have duplicated rows.")
   }
 
   # add a taxon index column (since we can't guarantee there's a "name" column)
   # use a very unique column name so we don't clobber any existing columns
-  taxdf$this_is_a_unique_index_column_name <- seq_len(nrow(taxdf))
+  data$this_is_a_unique_index_column_name <- seq_len(nrow(data))
 
   # replicate taxon rows for each interval they span
   dat_list <- lapply(seq_len(nrow(bins)), function(i) {
-    int_tax <- taxdf[
-      taxdf[, min_ma, drop = TRUE] < bins$max_ma[i] &
-        taxdf[, max_ma, drop = TRUE] > bins$min_ma[i],
+    int_tax <- data[
+      data[, min_ma, drop = TRUE] < bins$max_ma[i] &
+        data[, max_ma, drop = TRUE] > bins$min_ma[i],
     ]
     if (ext_orig) {
       int_tax$ext <- int_tax[, min_ma, drop = TRUE] >= bins$min_ma[i] &

--- a/R/tax_range_space.R
+++ b/R/tax_range_space.R
@@ -5,7 +5,7 @@
 #' hull, latitudinal range, maximum Great Circle Distance, and the number of
 #' occupied equal-area hexagonal grid cells.
 #'
-#' @param occdf \code{dataframe}. A dataframe of fossil occurrences. This
+#' @param data \code{dataframe}. A dataframe of fossil occurrences. This
 #'   dataframe should contain at least three columns: names of taxa, longitude
 #'   and latitude (see `name`, `lng`, and `lat` arguments).
 #' @param name \code{character}. The name of the column you wish to be treated
@@ -18,7 +18,7 @@
 #'   as the input latitude (e.g. "lat" or "p_lat"). NA data should be removed
 #'   prior to function call.
 #' @param method \code{character}. How should geographic range be calculated
-#'   for each taxon in `occdf`? Four options exist in this function: "con",
+#'   for each taxon in `data`? Four options exist in this function: "con",
 #'   "lat", "gcd", and "occ". See Details for a description of each.
 #' @param spacing \code{numeric}. The desired spacing (in km) between the
 #'   center of adjacent grid cells. Only required if the `method` argument is
@@ -51,18 +51,18 @@
 #' @details Four commonly applied approaches (Darroch et al. 2020)
 #' are available using the `tax_range_space` function for calculating ranges:
 #' - Convex hull: the "con" method calculates the geographic range of taxa
-#' using a convex hull for each taxon in `occdf`, and calculates the area of
+#' using a convex hull for each taxon in `data`, and calculates the area of
 #' the convex hull (in km\ifelse{html}{\out{<sup>2</sup>}}{\eqn{^2}}) using
 #' \code{\link[geosphere:areaPolygon]{geosphere::areaPolygon()}}. The
 #' convex hull method works by creating a polygon that encompasses all
 #' occurrence points of the taxon.
 #' - Latitudinal: the "lat" method calculates the palaeolatitudinal
-#' range of a taxon. It does so for each taxon in `occdf` by finding their
+#' range of a taxon. It does so for each taxon in `data` by finding their
 #' maximum and minimum latitudinal occurrence (from input `lat`).
 #' The palaeolatitudinal range of each taxon is also calculated (i.e. the
 #' difference between the minimum and maximum latitude).
 #' - Maximum Great Circle Distance: the "gcd" method calculates the maximum
-#' Great Circle Distance between occurrences for each taxon in `occdf`. It does
+#' Great Circle Distance between occurrences for each taxon in `data`. It does
 #' so using \code{\link[geosphere:distHaversine]{geosphere::distHaversine()}}.
 #' This function calculates Great Circle Distance using the Haversine method
 #' with the radius of the Earth set to the 6378.137 km.
@@ -97,24 +97,24 @@
 #' @importFrom h3jsr point_to_cell
 #' @examples
 #' # Grab internal data
-#' occdf <- tetrapods[1:100, ]
+#' data <- tetrapods[1:100, ]
 #' # Remove NAs
-#' occdf <- subset(occdf, !is.na(genus))
+#' data <- subset(data, !is.na(genus))
 #' # Convex hull
-#' ex1 <- tax_range_space(occdf = occdf, name = "genus", method = "con")
+#' ex1 <- tax_range_space(data = data, name = "genus", method = "con")
 #' # Latitudinal range
-#' ex2 <- tax_range_space(occdf = occdf, name = "genus", method = "lat")
+#' ex2 <- tax_range_space(data = data, name = "genus", method = "lat")
 #' # Great Circle Distance
-#' ex3 <- tax_range_space(occdf = occdf, name = "genus", method = "gcd")
+#' ex3 <- tax_range_space(data = data, name = "genus", method = "gcd")
 #' # Occupied grid cells
-#' ex4 <- tax_range_space(occdf = occdf, name = "genus",
+#' ex4 <- tax_range_space(data = data, name = "genus",
 #'                        method = "occ", spacing = 500)
 #' # Convex hull with coordinates
-#' ex5 <- tax_range_space(occdf = occdf, name = "genus", method = "con",
+#' ex5 <- tax_range_space(data = data, name = "genus", method = "con",
 #' coords = TRUE)
 #' @export
 tax_range_space <- function(
-  occdf,
+  data,
   name = "genus",
   lng = "lng",
   lat = "lat",
@@ -122,20 +122,20 @@ tax_range_space <- function(
   spacing = 100,
   coords = FALSE
 ) {
-  ensure_args_are_named(exceptions = "occdf")
+  ensure_args_are_named(exceptions = "data")
 
-  check_data_frame(occdf)
+  check_data_frame(data)
 
-  check_column_presence(occdf, name)
-  check_column_presence(occdf, lng)
-  check_column_presence(occdf, lat)
+  check_column_presence(data, name)
+  check_column_presence(data, lng)
+  check_column_presence(data, lat)
 
-  check_na(occdf, name)
-  check_na(occdf, lat)
-  check_na(occdf, lng)
+  check_na(data, name)
+  check_na(data, lat)
+  check_na(data, lng)
 
-  check_range(occdf, lat, -90, 90)
-  check_range(occdf, lng, -180, 180)
+  check_range(data, lat, -90, 90)
+  check_range(data, lng, -180, 180)
 
   rlang::check_number_decimal(spacing)
   rlang::check_bool(coords)
@@ -144,7 +144,7 @@ tax_range_space <- function(
   method <- rlang::arg_match(method, values = c("lat", "con", "gcd", "occ"))
 
   #=== Set-up ===
-  unique_taxa <- unique(occdf[, name, drop = TRUE])
+  unique_taxa <- unique(data[, name, drop = TRUE])
   # Order taxa
   unique_taxa <- sort(unique_taxa)
 
@@ -157,7 +157,7 @@ tax_range_space <- function(
       taxon <- unique_taxa[i]
       taxon_id <- i
       # Subset taxa
-      tmp <- occdf[which(occdf[, name, drop = TRUE] == unique_taxa[i]), ]
+      tmp <- data[which(data[, name, drop = TRUE] == unique_taxa[i]), ]
       # Calculate convex hull
       tmp <- tmp[
         chull(x = tmp[, lng, drop = TRUE], y = tmp[, lat, drop = TRUE]),
@@ -194,9 +194,9 @@ tax_range_space <- function(
     )
     # Run for loop across unique taxa
     for (i in seq_along(unique_taxa)) {
-      vec <- which(occdf[, name, drop = TRUE] == unique_taxa[i])
-      lat_df$max_lat[i] <- max(occdf[vec, lat])
-      lat_df$min_lat[i] <- min(occdf[vec, lat])
+      vec <- which(data[, name, drop = TRUE] == unique_taxa[i])
+      lat_df$max_lat[i] <- max(data[vec, lat])
+      lat_df$min_lat[i] <- min(data[vec, lat])
       lat_df$range_lat[i] <- lat_df$max_lat[i] - lat_df$min_lat[i]
     }
     # Remove row names
@@ -223,7 +223,7 @@ tax_range_space <- function(
       # taxon id
       taxon_id <- i
       # Subset df
-      tmp <- occdf[which(occdf[, name, drop = TRUE] == unique_taxa[i]), ]
+      tmp <- data[which(data[, name, drop = TRUE] == unique_taxa[i]), ]
       # Calculate GCD matrix using the Haversine method
       vals <- geosphere::distm(
         x = tmp[, c(lng, lat)],
@@ -283,7 +283,7 @@ tax_range_space <- function(
     # Run for loop over all unique taxa
     for (i in seq_along(unique_taxa)) {
       # Subset df
-      tmp <- occdf[which(occdf[, name, drop = TRUE] == unique_taxa[i]), ]
+      tmp <- data[which(data[, name, drop = TRUE] == unique_taxa[i]), ]
       # Extract cell ID
       n_cells <- suppressMessages(
         h3jsr::point_to_cell(tmp[, c(lng, lat)], res = grid$h3_resolution)

--- a/R/tax_range_strat.R
+++ b/R/tax_range_strat.R
@@ -3,7 +3,7 @@
 #' A function to plot the stratigraphic ranges of fossil taxa from occurrence
 #' data.
 #'
-#' @param occdf \code{dataframe}. A dataframe of fossil occurrences containing
+#' @param data \code{dataframe}. A dataframe of fossil occurrences containing
 #'   at least two columns: names of taxa, and their stratigraphic position (see
 #'   `name` and `level` arguments).
 #' @param name \code{character}. The name of the column you wish to be treated
@@ -88,17 +88,17 @@
 #' # Simulate certainty values
 #' certainty_sampled <- sample(x = 0:1, size = 50, replace = TRUE)
 #' # Combine into data frame
-#' occdf <- data.frame(taxon = tetrapod_names,
+#' data <- data.frame(taxon = tetrapod_names,
 #'                     bed = beds_sampled,
 #'                     certainty = certainty_sampled)
 #' # Plot stratigraphic ranges
 #' # Update margins for plotting
 #' par(mar = c(12, 5, 2, 2))
-#' tax_range_strat(occdf, name = "taxon")
-#' tax_range_strat(occdf, name = "taxon", certainty = "certainty",
+#' tax_range_strat(data, name = "taxon")
+#' tax_range_strat(data, name = "taxon", certainty = "certainty",
 #'                 plot_args = list(ylab = "Stratigraphic height (m)"))
 #' # Plot stratigraphic ranges with more labelling
-#' tax_range_strat(occdf, name = "taxon", certainty = "certainty", by = "name",
+#' tax_range_strat(data, name = "taxon", certainty = "certainty", by = "name",
 #'                 plot_args = list(main = "Section A",
 #'                                  ylab = "Stratigraphic height (m)"))
 #' eras_custom <- data.frame(name = c("Mesozoic", "Cenozoic"),
@@ -110,16 +110,16 @@
 #' # Update margins for plotting
 #' par(mar = c(12, 5, 6, 2))
 #' # Pull class data
-#' occdf$class <- tetrapods$class[1:50]
+#' data$class <- tetrapods$class[1:50]
 #' # Group stratigraphic ranges by class
-#' tax_range_strat(occdf, name = "taxon", group = "class",
+#' tax_range_strat(data, name = "taxon", group = "class",
 #'                 certainty = "certainty", by = "name",
 #'                 plot_args = list(main = "Section A",
 #'                                  ylab = "Stratigraphic height (m)"))
 #'
 #' @export
 tax_range_strat <- function(
-  occdf,
+  data,
   name = "genus",
   level = "bed",
   group = NULL,
@@ -129,23 +129,23 @@ tax_range_strat <- function(
   x_args = NULL,
   y_args = NULL
 ) {
-  ensure_args_are_named(exceptions = "occdf")
+  ensure_args_are_named(exceptions = "data")
 
-  check_data_frame(occdf)
-  check_column_presence(occdf, name)
-  check_column_presence(occdf, level)
+  check_data_frame(data)
+  check_column_presence(data, name)
+  check_column_presence(data, level)
 
-  check_class(occdf, level, "numeric")
-  check_na(occdf, name)
-  check_na(occdf, level)
+  check_class(data, level, "numeric")
+  check_na(data, name)
+  check_na(data, level)
 
   if (!is.null(group)) {
-    check_column_presence(occdf, group)
+    check_column_presence(data, group)
   }
 
   if (!is.null(certainty)) {
-    check_column_presence(occdf, certainty)
-    check_na(occdf, certainty)
+    check_column_presence(data, certainty)
+    check_na(data, certainty)
   }
 
   rlang::check_string(by)
@@ -153,18 +153,18 @@ tax_range_strat <- function(
 
   # Create pseudo-group if not provided (enable group_apply with no groups)
   if (is.null(group)) {
-    occdf$tmp_group <- 1
+    data$tmp_group <- 1
     g <- "tmp_group"
   } else {
     g <- group
   }
   # Calculate ranges
   ranges <- group_apply(
-    occdf,
+    data,
     group = g,
-    fun = function(occdf, name, level) {
+    fun = function(data, name, level) {
       #=== Set-up ===
-      unique_taxa <- unique(occdf[, name, drop = TRUE])
+      unique_taxa <- unique(data[, name, drop = TRUE])
       # Order taxa by name
       unique_taxa <- sort(unique_taxa)
 
@@ -189,7 +189,7 @@ tax_range_strat <- function(
       }
       # Run for loop across unique taxa
       for (i in seq_along(unique_taxa)) {
-        occ_filter <- occdf[(occdf[, name, drop = TRUE] == unique_taxa[i]), ]
+        occ_filter <- data[(data[, name, drop = TRUE] == unique_taxa[i]), ]
         ranges[i, 3] <- min(occ_filter[level])
         ranges[i, 4] <- max(occ_filter[level])
         if (!is.null(group)) {
@@ -230,13 +230,13 @@ tax_range_strat <- function(
   row.names(ranges) <- NULL
   # Get labels
   labels <- ranges[, c("taxon", "ID")]
-  # Join to occdf
-  occdf <- merge(occdf, labels, by.x = name, by.y = "taxon")
+  # Join to data
+  data <- merge(data, labels, by.x = name, by.y = "taxon")
 
   # Obtain uncertain occurrences
   if (!is.null(certainty)) {
-    certain <- occdf[(occdf[, certainty, drop = TRUE] != 0), ]
-    uncertain <- occdf[(occdf[, certainty, drop = TRUE] == 0), ]
+    certain <- data[(data[, certainty, drop = TRUE] != 0), ]
+    uncertain <- data[(data[, certainty, drop = TRUE] == 0), ]
   }
 
   #=== Plotting ===
@@ -365,8 +365,8 @@ tax_range_strat <- function(
   # Add points
   if (is.null(certainty)) {
     points(
-      y = occdf[, level, drop = TRUE],
-      x = occdf$ID,
+      y = data[, level, drop = TRUE],
+      x = data$ID,
       pch = pchs[1],
       col = cols[1],
       bg = bgs[1],
@@ -396,7 +396,7 @@ tax_range_strat <- function(
   }
   # Use defaults if not set
   if (!("at" %in% names(y_args))) {
-    y_args$at <- unique(occdf$bed)
+    y_args$at <- unique(data$bed)
   }
   do.call(axis, args = c(list(side = 2), y_args))
   # Plot x-axis

--- a/R/tax_range_time.R
+++ b/R/tax_range_time.R
@@ -3,7 +3,7 @@
 #' A function to calculate the temporal range of fossil taxa from occurrence
 #' data.
 #'
-#' @param occdf \code{dataframe}. A dataframe of fossil occurrences containing
+#' @param data \code{dataframe}. A dataframe of fossil occurrences containing
 #' at least three columns: names of taxa, minimum age and maximum age
 #' (see `name`, `min_ma`, and `max_ma` arguments).
 #' These ages should constrain the age range of the fossil occurrence
@@ -40,7 +40,7 @@
 #' returned.
 #'
 #' @details The temporal range(s) of taxa are calculated by extracting all
-#'   unique taxa (`name` column) from the input `occdf`, and checking their
+#'   unique taxa (`name` column) from the input `data`, and checking their
 #'   first and last appearance. The temporal duration of each taxon is also
 #'   calculated. If the input data columns contain NAs, these must be
 #'   removed prior to function call. A plot of the temporal range of each
@@ -67,31 +67,31 @@
 #' @importFrom graphics points strwidth
 #' @examples
 #' # Grab internal data
-#' occdf <- tetrapods
+#' data <- tetrapods
 #' # Remove NAs
-#' occdf <- subset(occdf, !is.na(order) & order != "NO_ORDER_SPECIFIED")
+#' data <- subset(data, !is.na(order) & order != "NO_ORDER_SPECIFIED")
 #' # Temporal range
-#' ex <- tax_range_time(occdf = occdf, name = "order", plot = TRUE)
+#' ex <- tax_range_time(data = data, name = "order", plot = TRUE)
 #' # Temporal range ordered by class
 #' # Update margins for plotting
 #' par(mar = c(8, 5, 6, 6))
-#' ex <- tax_range_time(occdf = occdf, name = "order", group = "class",
+#' ex <- tax_range_time(data = data, name = "order", group = "class",
 #'                      plot = TRUE)
 #' # Customise appearance
-#' ex <- tax_range_time(occdf = occdf, name = "order", group = "class",
+#' ex <- tax_range_time(data = data, name = "order", group = "class",
 #'                      plot = TRUE,
 #'                      plot_args = list(ylab = "Orders",
 #'                                       pch = 21, col = "black", bg = "blue",
 #'                                       lty = 2),
 #'                      intervals = list("periods", "eras"))
 #' # Control plotting order of groups
-#' occdf$class <- factor(x = occdf$class,
+#' data$class <- factor(x = data$class,
 #'                       levels = c("Reptilia", "Osteichthyes"))
-#' ex <- tax_range_time(occdf = occdf, name = "order",
+#' ex <- tax_range_time(data = data, name = "order",
 #'                      group = "class", plot = TRUE)
 #' @export
 tax_range_time <- function(
-  occdf,
+  data,
   name = "genus",
   min_ma = "min_ma",
   max_ma = "max_ma",
@@ -101,24 +101,24 @@ tax_range_time <- function(
   plot_args = NULL,
   intervals = "periods"
 ) {
-  ensure_args_are_named(exceptions = "occdf")
+  ensure_args_are_named(exceptions = "data")
 
-  check_data_frame(occdf)
+  check_data_frame(data)
 
-  check_column_presence(occdf, name)
-  check_column_presence(occdf, min_ma)
-  check_column_presence(occdf, max_ma)
+  check_column_presence(data, name)
+  check_column_presence(data, min_ma)
+  check_column_presence(data, max_ma)
 
-  check_na(occdf, name)
-  check_na(occdf, min_ma)
-  check_na(occdf, max_ma)
+  check_na(data, name)
+  check_na(data, min_ma)
+  check_na(data, max_ma)
 
-  check_class(occdf, min_ma, "numeric")
-  check_class(occdf, max_ma, "numeric")
-  check_min_lower_than_max(occdf, min_ma, max_ma)
+  check_class(data, min_ma, "numeric")
+  check_class(data, max_ma, "numeric")
+  check_min_lower_than_max(data, min_ma, max_ma)
 
   if (!is.null(group)) {
-    check_column_presence(occdf, group)
+    check_column_presence(data, group)
   }
 
   rlang::check_string(by)
@@ -134,18 +134,18 @@ tax_range_time <- function(
 
   # Create pseudo-group if not provided (enable group_apply with no groups)
   if (is.null(group)) {
-    occdf$tmp_group <- 1
+    data$tmp_group <- 1
     g <- "tmp_group"
   } else {
     g <- group
   }
   # Calculate ranges
   temp_df <- group_apply(
-    occdf,
+    data,
     group = g,
-    fun = function(occdf, name, min_ma, max_ma) {
+    fun = function(data, name, min_ma, max_ma) {
       #=== Set-up ===
-      unique_taxa <- unique(occdf[, name, drop = TRUE])
+      unique_taxa <- unique(data[, name, drop = TRUE])
       # Order taxa by name
       unique_taxa <- sort(unique_taxa)
 
@@ -161,9 +161,9 @@ tax_range_time <- function(
       )
       # Run for loop across unique taxa
       for (i in seq_along(unique_taxa)) {
-        vec <- which(occdf[, name, drop = TRUE] == unique_taxa[i])
-        temp_df$max_ma[i] <- max(occdf[vec, max_ma])
-        temp_df$min_ma[i] <- min(occdf[vec, min_ma])
+        vec <- which(data[, name, drop = TRUE] == unique_taxa[i])
+        temp_df$max_ma[i] <- max(data[vec, max_ma])
+        temp_df$min_ma[i] <- min(data[vec, min_ma])
         temp_df$range_myr[i] <- temp_df$max_ma[i] - temp_df$min_ma[i]
         temp_df$n_occ[i] <- length(vec)
       }

--- a/R/tax_unique.R
+++ b/R/tax_unique.R
@@ -7,23 +7,23 @@
 #' further information). This has previously been described as "cryptic
 #' diversity" (e.g. Mannion et al. 2011).
 #'
-#' @param occdf \code{dataframe}. A dataframe containing information on the
+#' @param data \code{dataframe}. A dataframe containing information on the
 #' occurrences or taxa to filter.
-#' @param binomial \code{character}. The name of the column in \code{occdf}
+#' @param binomial \code{character}. The name of the column in \code{data}
 #' containing the genus and species names of the occurrences, either in the
 #' form "genus species" or "genus_species".
-#' @param species \code{character}. The name of the column in \code{occdf}
+#' @param species \code{character}. The name of the column in \code{data}
 #' containing the species-level identifications (i.e. the specific epithet).
-#' @param genus \code{character}. The name of the column in \code{occdf}
+#' @param genus \code{character}. The name of the column in \code{data}
 #' containing the genus-level identifications.
 #' @param ... \code{character}. Other named arguments specifying columns of
 #' higher levels of taxonomy (e.g. subfamily, order, superclass). The names of
 #' the arguments will be the column names of the output, and the values of the
-#' arguments correspond to the columns of \code{occdf}. The given order of the
+#' arguments correspond to the columns of \code{data}. The given order of the
 #' arguments is the order in which they are filtered. Therefore, these arguments
 #' must be in ascending order from lowest to highest taxonomic rank (see
 #' examples below). At least one higher level of taxonomy must be specified.
-#' @param name \code{character}. The name of the column in \code{occdf}
+#' @param name \code{character}. The name of the column in \code{data}
 #' containing the taxonomic names at mixed taxonomic levels; the data column
 #' "accepted_name" in a [Paleobiology Database](https://paleobiodb.org/#/)
 #' occurrence dataframe is of this type.
@@ -36,7 +36,7 @@
 #' "species" or "genus" in the dataset (depending on the chosen resolution).
 #' The dataframe will include the taxonomic information provided into the
 #' function, as well as a column providing the 'unique' names of each taxon. If
-#' \code{append} is \code{TRUE}, the original dataframe (\code{occdf}) will be
+#' \code{append} is \code{TRUE}, the original dataframe (\code{data}) will be
 #' returned with these 'unique' names appended as a new column. Occurrences that
 #' are identified to a coarse taxonomic resolution and belong to a clade which
 #' is already represented within the dataset will have their 'unique' names
@@ -100,27 +100,27 @@
 #' @importFrom stats aggregate
 #' @examples
 #' #Retain unique species
-#' occdf <- tetrapods[1:100, ]
-#' species <- tax_unique(occdf = occdf, genus = "genus", family = "family",
+#' data <- tetrapods[1:100, ]
+#' species <- tax_unique(data = data, genus = "genus", family = "family",
 #' order = "order", class = "class", name = "accepted_name")
 #'
 #' #Retain unique genera
-#' genera <- tax_unique(occdf = occdf, genus = "genus", family = "family",
+#' genera <- tax_unique(data = data, genus = "genus", family = "family",
 #' order = "order", class = "class", resolution = "genus")
 #'
 #' #Append unique names to the original occurrences
-#' genera_append <- tax_unique(occdf = occdf, genus = "genus", family = "family",
+#' genera_append <- tax_unique(data = data, genus = "genus", family = "family",
 #' order = "order", class = "class", resolution = "genus", append = TRUE)
 #'
 #' #Create dataframe from lists
-#' occdf2 <- data.frame(species = c("rex", "aegyptiacus", NA), genus =
+#' data2 <- data.frame(species = c("rex", "aegyptiacus", NA), genus =
 #' c("Tyrannosaurus", "Spinosaurus", NA), family = c("Tyrannosauridae",
 #' "Spinosauridae", "Diplodocidae"))
-#' dinosaur_species <- tax_unique(occdf = occdf2, species = "species", genus =
+#' dinosaur_species <- tax_unique(data = data2, species = "species", genus =
 #' "genus", family = "family")
 #'
 #' #Retain unique genera per collection with group_apply
-#' genera <- group_apply(occdf = occdf,
+#' genera <- group_apply(data = data,
 #'                      group = c("collection_no"),
 #'                      fun = tax_unique,
 #'                      genus = "genus",
@@ -132,7 +132,7 @@
 #' @export
 #'
 tax_unique <- function(
-  occdf,
+  data,
   binomial = NULL,
   species = NULL,
   genus = NULL,
@@ -141,24 +141,24 @@ tax_unique <- function(
   resolution = "species",
   append = FALSE
 ) {
-  ensure_args_are_named(exceptions = "occdf")
+  ensure_args_are_named(exceptions = "data")
 
-  check_data_frame(occdf)
+  check_data_frame(data)
   rlang::check_bool(append)
   rlang::check_string(resolution)
   resolution <- rlang::arg_match(resolution, values = c("species", "genus"))
 
   if (!is.null(binomial)) {
-    check_column_presence(occdf, binomial)
+    check_column_presence(data, binomial)
   }
   if (!is.null(species)) {
-    check_column_presence(occdf, species)
+    check_column_presence(data, species)
   }
   if (!is.null(genus)) {
-    check_column_presence(occdf, genus)
+    check_column_presence(data, genus)
   }
   if (!is.null(name)) {
-    check_column_presence(occdf, name)
+    check_column_presence(data, name)
   }
 
   higher_args <- list(...)
@@ -173,38 +173,38 @@ tax_unique <- function(
   for (level_label in higher_names) {
     col_name <- higher_args[[level_label]]
     rlang::check_string(col_name, arg = level_label)
-    check_column_presence(occdf, col_name)
+    check_column_presence(data, col_name)
     #Substitute labels used in PBDB downloads
-    occdf[[col_name]] <-
+    data[[col_name]] <-
       gsub(
         "NO_FAMILY_SPECIFIED|NO_ORDER_SPECIFIED|NO_CLASS_SPECIFIED",
         NA,
-        occdf[[col_name]]
+        data[[col_name]]
       )
-    if (any(grepl("[[:punct:]]", occdf[[col_name]]))) {
+    if (any(grepl("[[:punct:]]", data[[col_name]]))) {
       cli::cli_abort(
         "Column {.val {level_label}} must not contain punctuation."
       )
     }
   }
 
-  if (!is.null(genus) && any(grepl("[[:punct:]]", occdf[[genus]]))) {
+  if (!is.null(genus) && any(grepl("[[:punct:]]", data[[genus]]))) {
     cli::cli_abort("Column {.val genus} must not contain punctuation.")
   }
 
-  if (!is.null(species) && any(grepl("[[:punct:]]", occdf[[species]]))) {
+  if (!is.null(species) && any(grepl("[[:punct:]]", data[[species]]))) {
     cli::cli_abort("Column {.val species} must not contain punctuation.")
   }
 
   if (
-    !is.null(binomial) && any(grepl("[^[:alnum:][:space:]]", occdf[[binomial]]))
+    !is.null(binomial) && any(grepl("[^[:alnum:][:space:]]", data[[binomial]]))
   ) {
     cli::cli_abort(
       "Column {.val binomial} must not contain punctuation except spaces or underscores."
     )
   }
 
-  if (!is.null(name) && any(grepl("[^[:alnum:][:space:]]", occdf[[name]]))) {
+  if (!is.null(name) && any(grepl("[^[:alnum:][:space:]]", data[[name]]))) {
     cli::cli_abort(
       "Column {.val name} must not contain punctuation except spaces or underscores."
     )
@@ -235,7 +235,7 @@ tax_unique <- function(
 
   #Run function
   genus_species <- NULL
-  occurrences <- occdf[, c(binomial, species, genus, higher_cols, name)]
+  occurrences <- data[, c(binomial, species, genus, higher_cols, name)]
 
   #Rename columns
   if (!is.null(species)) {
@@ -255,7 +255,7 @@ tax_unique <- function(
 
   #Change underscores in binomials to spaces
   if (!is.null(binomial)) {
-    occurrences$binomial <- gsub("_", " ", occdf$binomial)
+    occurrences$binomial <- gsub("_", " ", data$binomial)
   }
   if (!is.null(name)) {
     occurrences$name <- gsub("_", " ", occurrences$name)
@@ -419,11 +419,11 @@ tax_unique <- function(
 
   if (append) {
     # Convert back to original dataframe
-    occdf$unique_name <- NA
+    data$unique_name <- NA
     for (i in seq_len(nrow(to_retain))) {
-      occdf$unique_name[to_retain$rows[[i]]] <- to_retain$unique_name[i]
+      data$unique_name[to_retain$rows[[i]]] <- to_retain$unique_name[i]
     }
-    return(occdf)
+    return(data)
   } else {
     row.names(to_retain) <- NULL
     return(to_retain)

--- a/man/bin_lat.Rd
+++ b/man/bin_lat.Rd
@@ -4,10 +4,10 @@
 \alias{bin_lat}
 \title{Assign fossil occurrences to latitudinal bins}
 \usage{
-bin_lat(occdf, bins, lat = "lat", boundary = FALSE)
+bin_lat(data, bins, lat = "lat", boundary = FALSE)
 }
 \arguments{
-\item{occdf}{\code{dataframe}. A dataframe of the fossil occurrences you
+\item{data}{\code{dataframe}. A dataframe of the fossil occurrences you
 wish to bin. This dataframe should contain a column with the
 latitudinal coordinates of occurrence data.}
 
@@ -27,7 +27,7 @@ If \code{FALSE}, occurrences will be binned into the upper bin
 only (i.e. highest row number).}
 }
 \value{
-A dataframe of the original input \code{occdf} with appended
+A dataframe of the original input \code{data} with appended
 columns containing respective latitudinal bin information.
 }
 \description{
@@ -45,10 +45,10 @@ Sofia Galvan
 
 \examples{
 # Load occurrence data
-occdf <- tetrapods
+data <- tetrapods
 # Generate latitudinal bins
 bins <- lat_bins_degrees(size = 10)
 # Bin data
-occdf <- bin_lat(occdf = occdf, bins = bins, lat = "lat")
+data <- bin_lat(data = data, bins = bins, lat = "lat")
 
 }

--- a/man/bin_space.Rd
+++ b/man/bin_space.Rd
@@ -5,7 +5,7 @@
 \title{Assign fossil occurrences to spatial bins}
 \usage{
 bin_space(
-  occdf,
+  data,
   lng = "lng",
   lat = "lat",
   spacing = 100,
@@ -15,7 +15,7 @@ bin_space(
 )
 }
 \arguments{
-\item{occdf}{\code{dataframe}. A dataframe of the fossil occurrences (or
+\item{data}{\code{dataframe}. A dataframe of the fossil occurrences (or
 localities) you wish to bin. This dataframe should contain the decimal
 degree coordinates of your occurrences, and they should be of
 class \code{numeric}.}
@@ -42,8 +42,8 @@ be plotted?}
 }
 \value{
 If the \code{return} argument is set to \code{FALSE}, a dataframe is
-returned of the original input \code{occdf} with cell information. If \code{return} is
-set to \code{TRUE}, a list is returned with both the input \code{occdf} and grid
+returned of the original input \code{data} with cell information. If \code{return} is
+set to \code{TRUE}, a list is returned with both the input \code{data} and grid
 information and polygons.
 }
 \description{
@@ -92,23 +92,23 @@ Bethany Allen & Kilian Eichenseer
 data("reefs")
 
 # Reduce data for plotting
-occdf <- reefs[1:250, ]
+data <- reefs[1:250, ]
 
 # Bin data using a hexagonal equal-area grid
-ex1 <- bin_space(occdf = occdf, spacing = 500, plot = TRUE)
+ex1 <- bin_space(data = data, spacing = 500, plot = TRUE)
 
 # Bin data using a hexagonal equal-area grid and sub-grid
-ex2 <- bin_space(occdf = occdf, spacing = 1000, sub_grid = 250, plot = TRUE)
+ex2 <- bin_space(data = data, spacing = 1000, sub_grid = 250, plot = TRUE)
 
 # EXAMPLE: rarefy
 # Load data
-occdf <- tetrapods[1:250, ]
+data <- tetrapods[1:250, ]
 
 # Assign to spatial bin
-occdf <- bin_space(occdf = occdf, spacing = 1000, sub_grid = 250)
+data <- bin_space(data = data, spacing = 1000, sub_grid = 250)
 
 # Get unique bins
-bins <- unique(occdf$cell_ID)
+bins <- unique(data$cell_ID)
 
 # n reps
 n <- 10
@@ -116,8 +116,8 @@ n <- 10
 # Rarefy data across sub-grid grid cells
 # Returns a list with each element a bin with respective mean genus richness
 df <- lapply(bins, function(x) {
-  # subset occdf for respective grid cell
-  tmp <- occdf[which(occdf$cell_ID == x), ]
+  # subset data for respective grid cell
+  tmp <- data[which(data$cell_ID == x), ]
 
   # Which sub-grid cells are there within this bin?
   sub_bin <- unique(tmp$cell_ID_sub)

--- a/man/bin_time.Rd
+++ b/man/bin_time.Rd
@@ -5,7 +5,7 @@
 \title{Assign fossil occurrences to time bins}
 \usage{
 bin_time(
-  occdf,
+  data,
   min_ma = "min_ma",
   max_ma = "max_ma",
   bins,
@@ -16,7 +16,7 @@ bin_time(
 )
 }
 \arguments{
-\item{occdf}{\code{dataframe}. A dataframe of the fossil occurrences you
+\item{data}{\code{dataframe}. A dataframe of the fossil occurrences you
 wish to bin. This dataframe should contain at least two columns with
 \code{numeric} values: maximum age of occurrence and minimum age of
 occurrence (see \code{max_ma}, \code{min_ma}). If required, \code{numeric} ages can be
@@ -24,11 +24,11 @@ generated from interval names via the
 \code{\link[palaeoverse:look_up]{look_up()}} function.}
 
 \item{min_ma}{\code{character}. The name of the column you wish to be
-treated as the minimum age for \code{occdf} and \code{bins}, e.g. "min_ma"
+treated as the minimum age for \code{data} and \code{bins}, e.g. "min_ma"
 (default).}
 
 \item{max_ma}{\code{character}. The name of the column you wish to be
-treated as the maximum age for \code{occdf} and \code{bins}, e.g. "max_ma"
+treated as the maximum age for \code{data} and \code{bins}, e.g. "max_ma"
 (default).}
 
 \item{bins}{\code{dataframe}. A dataframe of the bins that you wish to
@@ -63,13 +63,13 @@ function arguments should therefore be scaled to be within these bounds.}
 }
 \value{
 For methods "mid", "majority" and "all", a \code{dataframe} of the
-original input \code{occdf} with the following appended columns is returned:
+original input \code{data} with the following appended columns is returned:
 occurrence id (\code{id}), number of bins that the occurrence age range covers
 (\code{n_bins}), bin assignment (\code{bin_assignment}), and bin midpoint
 (\code{bin_midpoint}). In the case of the "majority" method, an additional
 column of the majority percentage overlap (\code{overlap_percentage}) is also
 appended. For the "random" and "point" method, a \code{list} is returned
-(of length reps) with each element a copy of the \code{occdf} and appended
+(of length reps) with each element a copy of the \code{data} and appended
 columns (random: \code{bin_assignment} and \code{bin_midpoint}; point:
 \code{bin_assignment} and \code{point_estimates}).
 }
@@ -86,20 +86,20 @@ of the fossil occurrence age range to bin the occurrence.
 \item Majority: The "majority" method bins an occurrence into the bin which it
 most overlaps with. As part of this implementation, the majority
 percentage overlap of the occurrence is also calculated and returned as
-an additional column in \code{occdf}. If desired, these percentages can be
+an additional column in \code{data}. If desired, these percentages can be
 used to further filter an occurrence dataset.
 \item All: The "all" method bins an occurrence into every bin its age range
 covers. For occurrences with age ranges of more than one bin, the
 occurrence row is duplicated. Each occurrence is assigned an ID in the
-column \code{occdf$id} so that duplicates can be tracked. Additionally,
-\code{occdf$n_bins} records the number of bins each occurrence appears within.
+column \code{data$id} so that duplicates can be tracked. Additionally,
+\code{data$n_bins} records the number of bins each occurrence appears within.
 \item Random: The "random" method randomly samples X amount of bins (with
 replacement) from the bins that the fossil occurrence age range covers
 with equal probability regardless of bin length. The \code{reps} argument
 determines the number of times the sample process is repeated. All
 replications are stored as individual elements within the returned list
 with an appended \code{bin_assignment} and \code{bin_midpoint} column to the
-original input \code{occdf}. If desired, users can easily bind this list using
+original input \code{data}. If desired, users can easily bind this list using
 \code{do.call(rbind, x)}.
 \item Point: The "point" method randomly samples X (\code{reps}) amount of point age
 estimates from the age range of the fossil occurrence. Sampling follows a
@@ -113,7 +113,7 @@ scaled to be within these bounds. The \code{reps} argument determines the
 number of times the sample process is repeated. All replications are
 stored as individual elements within the returned list with an appended
 \code{bin_assignment} and \code{point_estimates} column to the original input
-\code{occdf}. If desired, users can easily bind this list using
+\code{data}. If desired, users can easily bind this list using
 \code{do.call(rbind, x)}.
 }
 }
@@ -127,22 +127,22 @@ stored as individual elements within the returned list with an appended
 
 \examples{
 #Grab internal tetrapod data
-occdf <- tetrapods[1:100, ]
+data <- tetrapods[1:100, ]
 bins <- time_bins()
 
 #Assign via midpoint age of fossil occurrence data
-ex1 <- bin_time(occdf = occdf, bins = bins, method = "mid")
+ex1 <- bin_time(data = data, bins = bins, method = "mid")
 
 #Assign to all bins that age range covers
-ex2 <- bin_time(occdf = occdf, bins = bins, method = "all")
+ex2 <- bin_time(data = data, bins = bins, method = "all")
 
 #Assign via majority overlap based on fossil occurrence age range
-ex3 <- bin_time(occdf = occdf, bins = bins, method = "majority")
+ex3 <- bin_time(data = data, bins = bins, method = "majority")
 
 #Assign randomly to overlapping bins based on fossil occurrence age range
-ex4 <- bin_time(occdf = occdf, bins = bins, method = "random", reps = 5)
+ex4 <- bin_time(data = data, bins = bins, method = "random", reps = 5)
 
 #Assign point estimates following a normal distribution
-ex5 <- bin_time(occdf = occdf, bins = bins, method = "point", reps = 5,
+ex5 <- bin_time(data = data, bins = bins, method = "point", reps = 5,
                 fun = dnorm, mean = 0.5, sd = 0.25)
 }

--- a/man/group_apply.Rd
+++ b/man/group_apply.Rd
@@ -4,10 +4,10 @@
 \alias{group_apply}
 \title{Apply a function over grouping(s) of data}
 \usage{
-group_apply(occdf, group, fun, ...)
+group_apply(data, group, fun, ...)
 }
 \arguments{
-\item{occdf}{\code{dataframe}. A dataframe of fossil occurrences or taxa,
+\item{data}{\code{dataframe}. A dataframe of fossil occurrences or taxa,
 as relevant to the desired function.
 This dataframe must contain the grouping variables and the necessary
 variables for the function you wish to call (see function-specific
@@ -19,7 +19,7 @@ one grouping variable will produce an output containing subgroups for each
 unique combination of values.}
 
 \item{fun}{\code{function}. The function you wish to apply to
-\code{occdf}. See details for compatible functions.}
+\code{data}. See details for compatible functions.}
 
 \item{...}{Additional arguments available in the called
 function. These arguments may be required for function arguments
@@ -77,13 +77,13 @@ Kilian Eichenseer & Bethany Allen
 \examples{
 # Examples
 # Get tetrapods data
-occdf <- tetrapods[1:100, ]
+data <- tetrapods[1:100, ]
 # Remove NA data
-occdf <- subset(occdf, !is.na(genus))
+data <- subset(data, !is.na(genus))
 # Count number of occurrences from each country
-ex1 <- group_apply(occdf = occdf, group = "cc", fun = nrow)
+ex1 <- group_apply(data = data, group = "cc", fun = nrow)
 # Unique genera per collection with group_apply and input arguments
-ex2 <- group_apply(occdf = occdf,
+ex2 <- group_apply(data = data,
                    group = "collection_no",
                    fun = tax_unique,
                    genus = "genus",
@@ -92,14 +92,14 @@ ex2 <- group_apply(occdf = occdf,
                    class = "class",
                    resolution = "genus")
 # Use multiple variables (number of occurrences per collection and formation)
-ex3 <- group_apply(occdf = occdf,
+ex3 <- group_apply(data = data,
                    group = c("collection_no", "formation"),
                    fun = nrow)
 # Compute counts of occurrences per latitudinal bin
 # Set up lat bins
 bins <- lat_bins_degrees()
 # bin occurrences
-occdf <- bin_lat(occdf = occdf, bins = bins)
+data <- bin_lat(data = data, bins = bins)
 # Calculate number of occurrences per bin
-ex4 <- group_apply(occdf = occdf, group = "lat_bin", fun = nrow)
+ex4 <- group_apply(data = data, group = "lat_bin", fun = nrow)
 }

--- a/man/look_up.Rd
+++ b/man/look_up.Rd
@@ -5,7 +5,7 @@
 \title{Look up geological intervals and assign geological stages}
 \usage{
 look_up(
-  occdf,
+  data,
   early_interval = "early_interval",
   late_interval = "late_interval",
   int_key = FALSE,
@@ -14,15 +14,15 @@ look_up(
 )
 }
 \arguments{
-\item{occdf}{\code{data.frame}. A dataframe of fossil occurrences or other
+\item{data}{\code{data.frame}. A dataframe of fossil occurrences or other
 geological data, with columns of class \code{character} specifying the
 earliest and the latest possible interval associated with each occurrence.}
 
-\item{early_interval}{\code{character}. Name of the column in \code{occdf} that
+\item{early_interval}{\code{character}. Name of the column in \code{data} that
 contains the earliest interval from which the occurrences are from. Defaults
 to "early_interval".}
 
-\item{late_interval}{\code{character}. Name of the column in \code{occdf} that
+\item{late_interval}{\code{character}. Name of the column in \code{data} that
 contains the latest interval from which the occurrences are from. Defaults
 to "late_interval".}
 
@@ -32,7 +32,7 @@ intervals.
 This dataframe should contain the following named columns containing
 \code{character} values: \cr
 \itemize{
-\item \code{interval_name} contains the names to be matched from \code{occdf} \cr
+\item \code{interval_name} contains the names to be matched from \code{data} \cr
 \item \code{early_stage} contains the names of the earliest stages
 corresponding to the intervals \cr
 \item \code{late_stage} contains the latest stage corresponding to the
@@ -103,33 +103,33 @@ Lewis A. Jones & Christopher D. Dean
 \examples{
 ## Just use GTS2020 (default):
 # create exemplary dataframe
-taxdf <- data.frame(name = c("A", "B", "C"),
+data <- data.frame(name = c("A", "B", "C"),
 early_interval = c("Maastrichtian", "Campanian", "Sinemurian"),
 late_interval = c("Maastrichtian", "Campanian", "Bartonian"))
 # assign stages and numerical ages
-taxdf <- look_up(taxdf)
+data <- look_up(data)
 
 ## Use exemplary int_key
 # Get internal reef data
-occdf <- reefs
+data <- reefs
  # assign stages and numerical ages
-occdf <- look_up(occdf,
+data <- look_up(data,
                 early_interval = "interval",
                 late_interval = "interval",
                 int_key = interval_key)
 
 ## Use exemplary int_key and return unassigned
 # Get internal tetrapod data
-occdf <- tetrapods
+data <- tetrapods
 # assign stages and numerical ages
-occdf <- look_up(occdf, int_key = palaeoverse::interval_key)
+data <- look_up(data, int_key = palaeoverse::interval_key)
 # return unassigned intervals
-unassigned <- look_up(occdf, int_key = palaeoverse::interval_key,
+unassigned <- look_up(data, int_key = palaeoverse::interval_key,
                       return_unassigned = TRUE)
 
 ## Use own key and GTS2012:
 # create example data
-occdf <- data.frame(
+data <- data.frame(
   stage = c("any Permian", "first Permian stage",
             "any Permian", "Roadian"))
 # create example key
@@ -138,7 +138,7 @@ interval_key <- data.frame(
   early_stage = c("Asselian", "Asselian"),
   late_stage = c("Changhsingian", "Asselian"))
 # assign stages and numerical ages:
-occdf <- look_up(occdf,
+data <- look_up(data,
                  early_interval = "stage", late_interval = "stage",
                  int_key = interval_key, assign_with_GTS = "GTS2012")
 

--- a/man/palaeorotate.Rd
+++ b/man/palaeorotate.Rd
@@ -5,7 +5,7 @@
 \title{Palaeorotate fossil occurrences}
 \usage{
 palaeorotate(
-  occdf,
+  data,
   lng = "lng",
   lat = "lat",
   age = "age",
@@ -16,8 +16,8 @@ palaeorotate(
 )
 }
 \arguments{
-\item{occdf}{\code{data.frame}. Fossil occurrences to be
-palaeogeographically reconstructed. \code{occdf} should contain columns
+\item{data}{\code{data.frame}. Fossil occurrences to be
+palaeogeographically reconstructed. \code{data} should contain columns
 with longitudinal and latitudinal coordinates, as well as age estimates.
 The age of rotation should be supplied in millions of years before
 present.}
@@ -163,18 +163,18 @@ Kilian Eichenseer, Lucas Buffan & Will Gearty
 \examples{
 \dontrun{
 #Generic example with a few occurrences
-occdf <- data.frame(lng = c(2, -103, -66),
+data <- data.frame(lng = c(2, -103, -66),
                 lat = c(46, 35, -7),
                 age = c(88, 125, 200))
 
 #Calculate palaeocoordinates using reconstruction files
-ex1 <- palaeorotate(occdf = occdf, method = "grid")
+ex1 <- palaeorotate(data = data, method = "grid")
 
 #Calculate palaeocoordinates using the GPlates API
-ex2 <- palaeorotate(occdf = occdf, method = "point")
+ex2 <- palaeorotate(data = data, method = "point")
 
 #Calculate uncertainity in palaeocoordinates from models
-ex3 <- palaeorotate(occdf = occdf,
+ex3 <- palaeorotate(data = data,
                     method = "grid",
                     model = c("MERDITH2021",
                               "GOLONKA",
@@ -190,10 +190,10 @@ data(tetrapods)
 tetrapods$age <- (tetrapods$max_ma + tetrapods$min_ma)/2
 
 #Rotate the data
-ex3 <- palaeorotate(occdf = tetrapods)
+ex3 <- palaeorotate(data = tetrapods)
 
 #Calculate uncertainity in palaeocoordinates from models
-ex4 <- palaeorotate(occdf = tetrapods,
+ex4 <- palaeorotate(data = tetrapods,
                     model = c("MERDITH2021",
                               "GOLONKA",
                               "PALEOMAP"),

--- a/man/tax_certainty.Rd
+++ b/man/tax_certainty.Rd
@@ -4,10 +4,10 @@
 \alias{tax_certainty}
 \title{Classify the certainty of taxonomic identifications}
 \usage{
-tax_certainty(taxdf, name, terms = NULL, certainty = c(1, 0), append = TRUE)
+tax_certainty(data, name, terms = NULL, certainty = c(1, 0), append = TRUE)
 }
 \arguments{
-\item{taxdf}{\code{data.frame}. A \code{data.frame} with a named column
+\item{data}{\code{data.frame}. A \code{data.frame} with a named column
 containing the taxonomic names to be checked.}
 
 \item{name}{\code{character}. The column name of the taxonomic names you
@@ -26,13 +26,13 @@ how certainty should be coded. The first element of the vector denotes
 status (default: 0).}
 
 \item{append}{\code{logical}. If \code{TRUE} (default), the returned object
-is a \code{data.frame} consisting of the input \code{taxdf} with a column
+is a \code{data.frame} consisting of the input \code{data} with a column
 denoting the taxonomic "certainty" appended. If \code{FALSE}, a two-column
 \code{data.frame} containing the input \code{name} and the taxonomic
 identification certainty status is returned.}
 }
 \value{
-When \code{append} is \code{TRUE}, the input \code{taxdf} with an
+When \code{append} is \code{TRUE}, the input \code{data} with an
 appended "certainty" column classifying each taxon (default). When
 \code{append} is \code{FALSE}, a two-column \code{data.frame} with input \code{name}
 and 'certainty' column classifying each taxon.
@@ -102,16 +102,16 @@ Lewis A. Jones, Bethany J. Allen, & William Gearty
 \examples{
 # Get internal data
 data(tetrapods)
-occdf <- tetrapods[1:100, ]
+data <- tetrapods[1:100, ]
 # Summarise taxonomic certainty
-certainty <- tax_certainty(taxdf = occdf, name = "identified_name",
+certainty <- tax_certainty(data = data, name = "identified_name",
                            append = FALSE)
 # Append uncertainty to dataframe
-certainty <- tax_certainty(taxdf = occdf, name = "identified_name",
+certainty <- tax_certainty(data = data, name = "identified_name",
                            certainty = c("certain", "uncertain"),
                            append = TRUE)
 # Turn off subspecies- and species-level screening terms (genus-level data)
-certainty <- tax_certainty(taxdf = occdf, name = "identified_name",
+certainty <- tax_certainty(data = data, name = "identified_name",
                            terms = list(subspecies = NULL, species = NULL),
                            certainty = c("certain", "uncertain"),
                            append = FALSE)

--- a/man/tax_check.Rd
+++ b/man/tax_check.Rd
@@ -5,7 +5,7 @@
 \title{Taxonomic spell check}
 \usage{
 tax_check(
-  taxdf,
+  data,
   name = "genus",
   group = NULL,
   dis = 0.05,
@@ -14,7 +14,7 @@ tax_check(
 )
 }
 \arguments{
-\item{taxdf}{\code{data.frame}. A dataframe with named columns containing
+\item{data}{\code{data.frame}. A dataframe with named columns containing
 taxon names (e.g. "species", "genus"). An optional column
 containing the groups (e.g. "family", "order") which taxon names
 belong to may also be provided (see \code{group} for details).
@@ -25,7 +25,7 @@ are ignored.}
 to check (e.g. "genus").}
 
 \item{group}{\code{character}. The column name of the higher taxonomic
-assignments in \code{taxdf} you wish to group by. If \code{NULL} (default), name
+assignments in \code{data} you wish to group by. If \code{NULL} (default), name
 comparison will be conducted within alphabetical groups.}
 
 \item{dis}{\code{numeric}. The dissimilarity threshold: a value greater than
@@ -104,9 +104,9 @@ Lewis A. Jones, Kilian Eichenseer & Christopher D. Dean
 # load occurrence data
 data("tetrapods")
 # Check taxon names alphabetically
-ex1 <- tax_check(taxdf = tetrapods, name = "genus", dis = 0.1)
+ex1 <- tax_check(data = tetrapods, name = "genus", dis = 0.1)
 # Check taxon names by group
-ex2 <- tax_check(taxdf = tetrapods, name = "genus",
+ex2 <- tax_check(data = tetrapods, name = "genus",
                  group = "family", dis = 0.1)
 }
 }

--- a/man/tax_expand_lat.Rd
+++ b/man/tax_expand_lat.Rd
@@ -4,10 +4,10 @@
 \alias{tax_expand_lat}
 \title{Generate pseudo-occurrences from latitudinal range data}
 \usage{
-tax_expand_lat(taxdf, bins, max_lat = "max_lat", min_lat = "min_lat")
+tax_expand_lat(data, bins, max_lat = "max_lat", min_lat = "min_lat")
 }
 \arguments{
-\item{taxdf}{\code{dataframe}. A dataframe of taxa (such as the
+\item{data}{\code{dataframe}. A dataframe of taxa (such as the
 output of the 'lat' method in \code{\link{tax_range_space}}) with columns
 containing latitudinal range data (maximum and minimum latitude). Column
 names are assumed to be "max_lat" and "min_lat", but may be updated via the
@@ -55,10 +55,10 @@ Christopher D. Dean
 
 \examples{
 bins <- lat_bins_degrees()
-taxdf <- data.frame(name = c("A", "B", "C"),
+data <- data.frame(name = c("A", "B", "C"),
                     max_lat = c(60, 20, -10),
                     min_lat = c(20, -40, -60))
-ex <- tax_expand_lat(taxdf = taxdf,
+ex <- tax_expand_lat(data = data,
                      bins = bins,
                      max_lat = "max_lat",
                      min_lat = "min_lat")

--- a/man/tax_expand_time.Rd
+++ b/man/tax_expand_time.Rd
@@ -5,7 +5,7 @@
 \title{Generate pseudo-occurrences from temporal range data}
 \usage{
 tax_expand_time(
-  taxdf,
+  data,
   max_ma = "max_ma",
   min_ma = "min_ma",
   bins = NULL,
@@ -15,7 +15,7 @@ tax_expand_time(
 )
 }
 \arguments{
-\item{taxdf}{\code{dataframe}. A dataframe of taxa (such as that
+\item{data}{\code{dataframe}. A dataframe of taxa (such as that
 produced by \code{\link{tax_range_time}}) with columns for the maximum and
 minimum ages (FADs and LADs). Each row should represent a unique taxon.
 Additional columns may be included (e.g. taxon names, additional taxonomy,
@@ -76,11 +76,11 @@ Lewis A. Jones
 }
 
 \examples{
-taxdf <- data.frame(name = c("A", "B", "C"),
+data <- data.frame(name = c("A", "B", "C"),
                     max_ma = c(150, 60, 30),
                     min_ma = c(110, 20, 0))
-ex <- tax_expand_time(taxdf)
+ex <- tax_expand_time(data)
 
 bins <- time_bins(scale = "GTS2012", rank = "stage")
-ex2 <- tax_expand_time(taxdf, bins = bins)
+ex2 <- tax_expand_time(data, bins = bins)
 }

--- a/man/tax_range_space.Rd
+++ b/man/tax_range_space.Rd
@@ -5,7 +5,7 @@
 \title{Calculate the geographic range of fossil taxa}
 \usage{
 tax_range_space(
-  occdf,
+  data,
   name = "genus",
   lng = "lng",
   lat = "lat",
@@ -15,7 +15,7 @@ tax_range_space(
 )
 }
 \arguments{
-\item{occdf}{\code{dataframe}. A dataframe of fossil occurrences. This
+\item{data}{\code{dataframe}. A dataframe of fossil occurrences. This
 dataframe should contain at least three columns: names of taxa, longitude
 and latitude (see \code{name}, \code{lng}, and \code{lat} arguments).}
 
@@ -32,7 +32,7 @@ as the input latitude (e.g. "lat" or "p_lat"). NA data should be removed
 prior to function call.}
 
 \item{method}{\code{character}. How should geographic range be calculated
-for each taxon in \code{occdf}? Four options exist in this function: "con",
+for each taxon in \code{data}? Four options exist in this function: "con",
 "lat", "gcd", and "occ". See Details for a description of each.}
 
 \item{spacing}{\code{numeric}. The desired spacing (in km) between the
@@ -78,18 +78,18 @@ Four commonly applied approaches (Darroch et al. 2020)
 are available using the \code{tax_range_space} function for calculating ranges:
 \itemize{
 \item Convex hull: the "con" method calculates the geographic range of taxa
-using a convex hull for each taxon in \code{occdf}, and calculates the area of
+using a convex hull for each taxon in \code{data}, and calculates the area of
 the convex hull (in km\ifelse{html}{\out{<sup>2</sup>}}{\eqn{^2}}) using
 \code{\link[geosphere:areaPolygon]{geosphere::areaPolygon()}}. The
 convex hull method works by creating a polygon that encompasses all
 occurrence points of the taxon.
 \item Latitudinal: the "lat" method calculates the palaeolatitudinal
-range of a taxon. It does so for each taxon in \code{occdf} by finding their
+range of a taxon. It does so for each taxon in \code{data} by finding their
 maximum and minimum latitudinal occurrence (from input \code{lat}).
 The palaeolatitudinal range of each taxon is also calculated (i.e. the
 difference between the minimum and maximum latitude).
 \item Maximum Great Circle Distance: the "gcd" method calculates the maximum
-Great Circle Distance between occurrences for each taxon in \code{occdf}. It does
+Great Circle Distance between occurrences for each taxon in \code{data}. It does
 so using \code{\link[geosphere:distHaversine]{geosphere::distHaversine()}}.
 This function calculates Great Circle Distance using the Haversine method
 with the radius of the Earth set to the 6378.137 km.
@@ -129,19 +129,19 @@ Bethany Allen & Christopher D. Dean
 
 \examples{
 # Grab internal data
-occdf <- tetrapods[1:100, ]
+data <- tetrapods[1:100, ]
 # Remove NAs
-occdf <- subset(occdf, !is.na(genus))
+data <- subset(data, !is.na(genus))
 # Convex hull
-ex1 <- tax_range_space(occdf = occdf, name = "genus", method = "con")
+ex1 <- tax_range_space(data = data, name = "genus", method = "con")
 # Latitudinal range
-ex2 <- tax_range_space(occdf = occdf, name = "genus", method = "lat")
+ex2 <- tax_range_space(data = data, name = "genus", method = "lat")
 # Great Circle Distance
-ex3 <- tax_range_space(occdf = occdf, name = "genus", method = "gcd")
+ex3 <- tax_range_space(data = data, name = "genus", method = "gcd")
 # Occupied grid cells
-ex4 <- tax_range_space(occdf = occdf, name = "genus",
+ex4 <- tax_range_space(data = data, name = "genus",
                        method = "occ", spacing = 500)
 # Convex hull with coordinates
-ex5 <- tax_range_space(occdf = occdf, name = "genus", method = "con",
+ex5 <- tax_range_space(data = data, name = "genus", method = "con",
 coords = TRUE)
 }

--- a/man/tax_range_strat.Rd
+++ b/man/tax_range_strat.Rd
@@ -5,7 +5,7 @@
 \title{Generate a stratigraphic section plot}
 \usage{
 tax_range_strat(
-  occdf,
+  data,
   name = "genus",
   level = "bed",
   group = NULL,
@@ -17,7 +17,7 @@ tax_range_strat(
 )
 }
 \arguments{
-\item{occdf}{\code{dataframe}. A dataframe of fossil occurrences containing
+\item{data}{\code{dataframe}. A dataframe of fossil occurrences containing
 at least two columns: names of taxa, and their stratigraphic position (see
 \code{name} and \code{level} arguments).}
 
@@ -122,17 +122,17 @@ beds_sampled <- sample.int(n = 10, size = 50, replace = TRUE)
 # Simulate certainty values
 certainty_sampled <- sample(x = 0:1, size = 50, replace = TRUE)
 # Combine into data frame
-occdf <- data.frame(taxon = tetrapod_names,
+data <- data.frame(taxon = tetrapod_names,
                     bed = beds_sampled,
                     certainty = certainty_sampled)
 # Plot stratigraphic ranges
 # Update margins for plotting
 par(mar = c(12, 5, 2, 2))
-tax_range_strat(occdf, name = "taxon")
-tax_range_strat(occdf, name = "taxon", certainty = "certainty",
+tax_range_strat(data, name = "taxon")
+tax_range_strat(data, name = "taxon", certainty = "certainty",
                 plot_args = list(ylab = "Stratigraphic height (m)"))
 # Plot stratigraphic ranges with more labelling
-tax_range_strat(occdf, name = "taxon", certainty = "certainty", by = "name",
+tax_range_strat(data, name = "taxon", certainty = "certainty", by = "name",
                 plot_args = list(main = "Section A",
                                  ylab = "Stratigraphic height (m)"))
 eras_custom <- data.frame(name = c("Mesozoic", "Cenozoic"),
@@ -144,9 +144,9 @@ title(xlab = "Taxon", line = 10.5)
 # Update margins for plotting
 par(mar = c(12, 5, 6, 2))
 # Pull class data
-occdf$class <- tetrapods$class[1:50]
+data$class <- tetrapods$class[1:50]
 # Group stratigraphic ranges by class
-tax_range_strat(occdf, name = "taxon", group = "class",
+tax_range_strat(data, name = "taxon", group = "class",
                 certainty = "certainty", by = "name",
                 plot_args = list(main = "Section A",
                                  ylab = "Stratigraphic height (m)"))

--- a/man/tax_range_time.Rd
+++ b/man/tax_range_time.Rd
@@ -5,7 +5,7 @@
 \title{Calculate the temporal range of fossil taxa}
 \usage{
 tax_range_time(
-  occdf,
+  data,
   name = "genus",
   min_ma = "min_ma",
   max_ma = "max_ma",
@@ -17,7 +17,7 @@ tax_range_time(
 )
 }
 \arguments{
-\item{occdf}{\code{dataframe}. A dataframe of fossil occurrences containing
+\item{data}{\code{dataframe}. A dataframe of fossil occurrences containing
 at least three columns: names of taxa, minimum age and maximum age
 (see \code{name}, \code{min_ma}, and \code{max_ma} arguments).
 These ages should constrain the age range of the fossil occurrence
@@ -68,7 +68,7 @@ data.
 }
 \details{
 The temporal range(s) of taxa are calculated by extracting all
-unique taxa (\code{name} column) from the input \code{occdf}, and checking their
+unique taxa (\code{name} column) from the input \code{data}, and checking their
 first and last appearance. The temporal duration of each taxon is also
 calculated. If the input data columns contain NAs, these must be
 removed prior to function call. A plot of the temporal range of each
@@ -102,26 +102,26 @@ Bethany Allen, Christopher D. Dean & Kilian Eichenseer
 
 \examples{
 # Grab internal data
-occdf <- tetrapods
+data <- tetrapods
 # Remove NAs
-occdf <- subset(occdf, !is.na(order) & order != "NO_ORDER_SPECIFIED")
+data <- subset(data, !is.na(order) & order != "NO_ORDER_SPECIFIED")
 # Temporal range
-ex <- tax_range_time(occdf = occdf, name = "order", plot = TRUE)
+ex <- tax_range_time(data = data, name = "order", plot = TRUE)
 # Temporal range ordered by class
 # Update margins for plotting
 par(mar = c(8, 5, 6, 6))
-ex <- tax_range_time(occdf = occdf, name = "order", group = "class",
+ex <- tax_range_time(data = data, name = "order", group = "class",
                      plot = TRUE)
 # Customise appearance
-ex <- tax_range_time(occdf = occdf, name = "order", group = "class",
+ex <- tax_range_time(data = data, name = "order", group = "class",
                      plot = TRUE,
                      plot_args = list(ylab = "Orders",
                                       pch = 21, col = "black", bg = "blue",
                                       lty = 2),
                      intervals = list("periods", "eras"))
 # Control plotting order of groups
-occdf$class <- factor(x = occdf$class,
+data$class <- factor(x = data$class,
                       levels = c("Reptilia", "Osteichthyes"))
-ex <- tax_range_time(occdf = occdf, name = "order",
+ex <- tax_range_time(data = data, name = "order",
                      group = "class", plot = TRUE)
 }

--- a/man/tax_unique.Rd
+++ b/man/tax_unique.Rd
@@ -5,7 +5,7 @@
 \title{Filter occurrences to unique taxa}
 \usage{
 tax_unique(
-  occdf,
+  data,
   binomial = NULL,
   species = NULL,
   genus = NULL,
@@ -16,28 +16,28 @@ tax_unique(
 )
 }
 \arguments{
-\item{occdf}{\code{dataframe}. A dataframe containing information on the
+\item{data}{\code{dataframe}. A dataframe containing information on the
 occurrences or taxa to filter.}
 
-\item{binomial}{\code{character}. The name of the column in \code{occdf}
+\item{binomial}{\code{character}. The name of the column in \code{data}
 containing the genus and species names of the occurrences, either in the
 form "genus species" or "genus_species".}
 
-\item{species}{\code{character}. The name of the column in \code{occdf}
+\item{species}{\code{character}. The name of the column in \code{data}
 containing the species-level identifications (i.e. the specific epithet).}
 
-\item{genus}{\code{character}. The name of the column in \code{occdf}
+\item{genus}{\code{character}. The name of the column in \code{data}
 containing the genus-level identifications.}
 
 \item{...}{\code{character}. Other named arguments specifying columns of
 higher levels of taxonomy (e.g. subfamily, order, superclass). The names of
 the arguments will be the column names of the output, and the values of the
-arguments correspond to the columns of \code{occdf}. The given order of the
+arguments correspond to the columns of \code{data}. The given order of the
 arguments is the order in which they are filtered. Therefore, these arguments
 must be in ascending order from lowest to highest taxonomic rank (see
 examples below). At least one higher level of taxonomy must be specified.}
 
-\item{name}{\code{character}. The name of the column in \code{occdf}
+\item{name}{\code{character}. The name of the column in \code{data}
 containing the taxonomic names at mixed taxonomic levels; the data column
 "accepted_name" in a \href{https://paleobiodb.org/#/}{Paleobiology Database}
 occurrence dataframe is of this type.}
@@ -53,7 +53,7 @@ A \code{dataframe} of taxa, with each row corresponding to a unique
 "species" or "genus" in the dataset (depending on the chosen resolution).
 The dataframe will include the taxonomic information provided into the
 function, as well as a column providing the 'unique' names of each taxon. If
-\code{append} is \code{TRUE}, the original dataframe (\code{occdf}) will be
+\code{append} is \code{TRUE}, the original dataframe (\code{data}) will be
 returned with these 'unique' names appended as a new column. Occurrences that
 are identified to a coarse taxonomic resolution and belong to a clade which
 is already represented within the dataset will have their 'unique' names
@@ -133,27 +133,27 @@ Lewis A. Jones & William Gearty
 
 \examples{
 #Retain unique species
-occdf <- tetrapods[1:100, ]
-species <- tax_unique(occdf = occdf, genus = "genus", family = "family",
+data <- tetrapods[1:100, ]
+species <- tax_unique(data = data, genus = "genus", family = "family",
 order = "order", class = "class", name = "accepted_name")
 
 #Retain unique genera
-genera <- tax_unique(occdf = occdf, genus = "genus", family = "family",
+genera <- tax_unique(data = data, genus = "genus", family = "family",
 order = "order", class = "class", resolution = "genus")
 
 #Append unique names to the original occurrences
-genera_append <- tax_unique(occdf = occdf, genus = "genus", family = "family",
+genera_append <- tax_unique(data = data, genus = "genus", family = "family",
 order = "order", class = "class", resolution = "genus", append = TRUE)
 
 #Create dataframe from lists
-occdf2 <- data.frame(species = c("rex", "aegyptiacus", NA), genus =
+data2 <- data.frame(species = c("rex", "aegyptiacus", NA), genus =
 c("Tyrannosaurus", "Spinosaurus", NA), family = c("Tyrannosauridae",
 "Spinosauridae", "Diplodocidae"))
-dinosaur_species <- tax_unique(occdf = occdf2, species = "species", genus =
+dinosaur_species <- tax_unique(data = data2, species = "species", genus =
 "genus", family = "family")
 
 #Retain unique genera per collection with group_apply
-genera <- group_apply(occdf = occdf,
+genera <- group_apply(data = data,
                      group = c("collection_no"),
                      fun = tax_unique,
                      genus = "genus",

--- a/tests/testthat/_snaps/bin_lat.md
+++ b/tests/testthat/_snaps/bin_lat.md
@@ -10,7 +10,7 @@
 ---
 
     Code
-      bin_lat(occdf = tetrapods, bins)
+      bin_lat(data = tetrapods, bins)
     Condition
       Error in `bin_lat()`:
       ! All arguments must be named.
@@ -37,15 +37,15 @@
 # bin_lat error handling
 
     Code
-      bin_lat(occdf = 2, bins = bins, lat = "lat")
+      bin_lat(data = 2, bins = bins, lat = "lat")
     Condition
       Error in `bin_lat()`:
-      ! `occdf` must be of class <data.frame>, not the number 2.
+      ! `data` must be of class <data.frame>, not the number 2.
 
 ---
 
     Code
-      bin_lat(occdf = occdf, bins = 2, lat = "lat")
+      bin_lat(data = data, bins = 2, lat = "lat")
     Condition
       Error in `bin_lat()`:
       ! `bins` must be of class <data.frame>, not the number 2.
@@ -53,15 +53,15 @@
 ---
 
     Code
-      bin_lat(occdf = occdf, bins = bins, lat = "plat")
+      bin_lat(data = data, bins = bins, lat = "plat")
     Condition
       Error in `bin_lat()`:
-      ! Column "plat" not found in `occdf`.
+      ! Column "plat" not found in `data`.
 
 ---
 
     Code
-      bin_lat(occdf = occdf, bins = bins2, lat = "lat")
+      bin_lat(data = data, bins = bins2, lat = "lat")
     Condition
       Error in `bin_lat()`:
       ! Column "bin" not found in `bins`.
@@ -69,7 +69,7 @@
 ---
 
     Code
-      bin_lat(occdf = occdf, bins = bins2, lat = "lat")
+      bin_lat(data = data, bins = bins2, lat = "lat")
     Condition
       Error in `bin_lat()`:
       ! Column "min" not found in `bins`.
@@ -77,7 +77,7 @@
 ---
 
     Code
-      bin_lat(occdf = occdf, bins = bins2, lat = "lat")
+      bin_lat(data = data, bins = bins2, lat = "lat")
     Condition
       Error in `bin_lat()`:
       ! Column "max" not found in `bins`.
@@ -85,17 +85,17 @@
 ---
 
     Code
-      bin_lat(occdf = occdf, bins = bins, lat = "lat")
+      bin_lat(data = data, bins = bins, lat = "lat")
     Condition
       Error in `bin_lat()`:
-      ! Column "lat" in `occdf` must not have missing values.
+      ! Column "lat" in `data` must not have missing values.
 
 ---
 
     Code
-      bin_lat(occdf = occdf, bins = bins, lat = "lat")
+      bin_lat(data = data, bins = bins, lat = "lat")
     Condition
       Error in `bin_lat()`:
-      ! All values of column "lat" in `occdf` must be between -90 and 90.
+      ! All values of column "lat" in `data` must be between -90 and 90.
       i Value(s) outside the range: 91.
 

--- a/tests/testthat/_snaps/bin_space.md
+++ b/tests/testthat/_snaps/bin_space.md
@@ -1,51 +1,51 @@
 # bin_space errors with unnamed args
 
     Code
-      bin_space(occdf, "lng")
+      bin_space(data, "lng")
     Condition
       Error in `bin_space()`:
-      ! All arguments must be named (except for "occdf").
+      ! All arguments must be named (except for "data").
       i Currently, there is 1 argument that should be named.
 
 ---
 
     Code
-      bin_space(occdf = occdf, "lng")
+      bin_space(data = data, "lng")
     Condition
       Error in `bin_space()`:
-      ! All arguments must be named (except for "occdf").
+      ! All arguments must be named (except for "data").
       i Currently, there is 1 argument that should be named.
 
 ---
 
     Code
-      bin_space(occdf, "lng", "lat")
+      bin_space(data, "lng", "lat")
     Condition
       Error in `bin_space()`:
-      ! All arguments must be named (except for "occdf").
+      ! All arguments must be named (except for "data").
       i Currently, there are 2 arguments that should be named.
 
 ---
 
     Code
-      bin_space(occdf, "lng", lat = "lat")
+      bin_space(data, "lng", lat = "lat")
     Condition
       Error in `bin_space()`:
-      ! All arguments must be named (except for "occdf").
+      ! All arguments must be named (except for "data").
       i Currently, there is 1 argument that should be named.
 
 # bin_space error handling
 
     Code
-      bin_space(occdf = matrix(tetrapods))
+      bin_space(data = matrix(tetrapods))
     Condition
       Error in `bin_space()`:
-      ! `occdf` must be of class <data.frame>, not a list matrix.
+      ! `data` must be of class <data.frame>, not a list matrix.
 
 ---
 
     Code
-      bin_space(occdf = tetrapods, spacing = NA)
+      bin_space(data = tetrapods, spacing = NA)
     Condition
       Error in `bin_space()`:
       ! `spacing` must be of class <numeric>, not `NA`.
@@ -53,7 +53,7 @@
 ---
 
     Code
-      bin_space(occdf = tetrapods, spacing = 1:2)
+      bin_space(data = tetrapods, spacing = 1:2)
     Condition
       Error in `bin_space()`:
       ! `spacing` must be of length 1, not 2.
@@ -61,7 +61,7 @@
 ---
 
     Code
-      bin_space(occdf = tetrapods, sub_grid = 1:2)
+      bin_space(data = tetrapods, sub_grid = 1:2)
     Condition
       Error in `bin_space()`:
       ! `sub_grid` must be of length 1, not 2.
@@ -69,7 +69,7 @@
 ---
 
     Code
-      bin_space(occdf = tetrapods, spacing = 1000, sub_grid = NA)
+      bin_space(data = tetrapods, spacing = 1000, sub_grid = NA)
     Condition
       Error in `bin_space()`:
       ! `sub_grid` must be of class <numeric> or `NULL`, not `NA`.
@@ -77,7 +77,7 @@
 ---
 
     Code
-      bin_space(occdf = tetrapods, return = "TRUE")
+      bin_space(data = tetrapods, return = "TRUE")
     Condition
       Error in `bin_space()`:
       ! `return` must be `TRUE` or `FALSE`, not the string "TRUE".
@@ -85,15 +85,15 @@
 ---
 
     Code
-      bin_space(occdf = tetrapods, lng = "long", lat = "latit")
+      bin_space(data = tetrapods, lng = "long", lat = "latit")
     Condition
       Error in `bin_space()`:
-      ! Column "latit" not found in `occdf`.
+      ! Column "latit" not found in `data`.
 
 ---
 
     Code
-      bin_space(occdf = tetrapods, spacing = 1000, sub_grid = 1000)
+      bin_space(data = tetrapods, spacing = 1000, sub_grid = 1000)
     Condition
       Error in `bin_space()`:
       ! `spacing` and `sub_grid` values result in the same resolution.
@@ -102,34 +102,34 @@
 ---
 
     Code
-      bin_space(occdf = occdf)
+      bin_space(data = data)
     Condition
       Error in `bin_space()`:
-      ! All values of column "lat" in `occdf` must be between -90 and 90.
+      ! All values of column "lat" in `data` must be between -90 and 90.
       i Value(s) outside the range: 94.
 
 ---
 
     Code
-      bin_space(occdf = occdf)
+      bin_space(data = data)
     Condition
       Error in `bin_space()`:
-      ! Column "lat" in `occdf` must be <numeric>, not <character>.
+      ! Column "lat" in `data` must be <numeric>, not <character>.
 
 ---
 
     Code
-      bin_space(occdf = occdf)
+      bin_space(data = data)
     Condition
       Error in `bin_space()`:
-      ! All values of column "lng" in `occdf` must be between -180 and 180.
+      ! All values of column "lng" in `data` must be between -180 and 180.
       i Value(s) outside the range: 184.
 
 ---
 
     Code
-      bin_space(occdf = occdf)
+      bin_space(data = data)
     Condition
       Error in `bin_space()`:
-      ! Column "lng" in `occdf` must be <numeric>, not <character>.
+      ! Column "lng" in `data` must be <numeric>, not <character>.
 

--- a/tests/testthat/_snaps/bin_time.md
+++ b/tests/testthat/_snaps/bin_time.md
@@ -1,10 +1,10 @@
-# wrong input for occdf
+# wrong input for data
 
     Code
-      bin_time(occdf = c(50, 20, 10))
+      bin_time(data = c(50, 20, 10))
     Condition
       Error in `bin_time()`:
-      ! `occdf` must be of class <data.frame>, not a double vector.
+      ! `data` must be of class <data.frame>, not a double vector.
 
 ---
 
@@ -12,12 +12,12 @@
       bin_time(bins = c(50, 20, 10))
     Condition
       Error in `bin_time()`:
-      ! `occdf` must be of class <data.frame>, not absent.
+      ! `data` must be of class <data.frame>, not absent.
 
 ---
 
     Code
-      bin_time(occdf = data.frame(), bins = c(50, 20, 10))
+      bin_time(data = data.frame(), bins = c(50, 20, 10))
     Condition
       Error in `bin_time()`:
       ! `bins` must be of class <data.frame>, not a double vector.
@@ -25,31 +25,23 @@
 ---
 
     Code
-      bin_time(occdf = data.frame(), bins = data.frame(), method = "mid")
+      bin_time(data = data.frame(), bins = data.frame(), method = "mid")
     Condition
       Error in `bin_time()`:
-      ! Column "min_ma" not found in `occdf`.
+      ! Column "min_ma" not found in `data`.
 
 ---
 
     Code
-      bin_time(occdf = data.frame(), bins = data.frame(), method = "mid")
+      bin_time(data = data.frame(), bins = data.frame(), method = "mid")
     Condition
       Error in `bin_time()`:
-      ! Column "min_ma" not found in `occdf`.
+      ! Column "min_ma" not found in `data`.
 
 ---
 
     Code
-      bin_time(occdf = test_occdf, bins = data.frame(), method = "mid")
-    Condition
-      Error in `bin_time()`:
-      ! Column "min_ma" not found in `bins`.
-
----
-
-    Code
-      bin_time(occdf = test_occdf, bins = data.frame(), method = "mid")
+      bin_time(data = test_data, bins = data.frame(), method = "mid")
     Condition
       Error in `bin_time()`:
       ! Column "min_ma" not found in `bins`.
@@ -57,24 +49,32 @@
 ---
 
     Code
-      bin_time(bins = mtcars, occdf = c(50, 20, 10))
+      bin_time(data = test_data, bins = data.frame(), method = "mid")
     Condition
       Error in `bin_time()`:
-      ! `occdf` must be of class <data.frame>, not a double vector.
+      ! Column "min_ma" not found in `bins`.
 
 ---
 
     Code
-      bin_time(occdf, bins = bins)
+      bin_time(bins = mtcars, data = c(50, 20, 10))
+    Condition
+      Error in `bin_time()`:
+      ! `data` must be of class <data.frame>, not a double vector.
+
+---
+
+    Code
+      bin_time(data, bins = bins)
     Condition
       Error in `bin_time()`:
       ! Maximum age must be larger than or equal to minimum age.
-      i Row(s) of `occdf` where "max_ma" is smaller than "min_ma": 2, 3.
+      i Row(s) of `data` where "max_ma" is smaller than "min_ma": 2, 3.
 
 ---
 
     Code
-      bin_time(occdf, bins = bins)
+      bin_time(data, bins = bins)
     Condition
       Error in `bin_time()`:
       ! Maximum age must be larger than or equal to minimum age.
@@ -83,7 +83,7 @@
 # wrong input for method
 
     Code
-      bin_time(occdf = occdf, bins = bins, method = "foo")
+      bin_time(data = data, bins = bins, method = "foo")
     Condition
       Error in `bin_time()`:
       ! `method` must be one of "mid", "majority", "all", "random", or "point", not "foo".
@@ -91,7 +91,7 @@
 # wrong input for reps
 
     Code
-      bin_time(occdf = occdf, bins = bins, method = "random", reps = TRUE)
+      bin_time(data = data, bins = bins, method = "random", reps = TRUE)
     Condition
       Error in `bin_time()`:
       ! `reps` must be of class <numeric>, not `TRUE`.
@@ -99,7 +99,7 @@
 # wrong input for fun
 
     Code
-      bin_time(occdf = occdf, bins = bins, method = "point", fun = NULL)
+      bin_time(data = data, bins = bins, method = "point", fun = NULL)
     Condition
       Error in `bin_time()`:
       ! Setting `method = "point"` requires `fun` to be a function.
@@ -108,7 +108,7 @@
 ---
 
     Code
-      bin_time(occdf = occdf, bins = bins, method = "point", fun = 1)
+      bin_time(data = data, bins = bins, method = "point", fun = 1)
     Condition
       Error in `bin_time()`:
       ! Setting `method = "point"` requires `fun` to be a function.
@@ -117,7 +117,7 @@
 ---
 
     Code
-      bin_time(occdf = occdf, bins = bins, method = "point", fun = dnorm, x = 1)
+      bin_time(data = data, bins = bins, method = "point", fun = dnorm, x = 1)
     Condition
       Error in `bin_time()`:
       ! `x` should not be specified. This is generated internally.
@@ -125,7 +125,7 @@
 ---
 
     Code
-      bin_time(occdf = occdf, bins = bins, method = "point", fun = dnorm, test = 1)
+      bin_time(data = data, bins = bins, method = "point", fun = dnorm, test = 1)
     Condition
       Error in `bin_time()`:
       ! `test` is not a valid argument for the specified function
@@ -133,7 +133,7 @@
 ---
 
     Code
-      bin_time(occdf = occdf, bins = bins, method = "point", fun = dnorm, test1 = 1,
+      bin_time(data = data, bins = bins, method = "point", fun = dnorm, test1 = 1,
         test2 = 1)
     Condition
       Error in `bin_time()`:
@@ -142,7 +142,7 @@
 # errors in data for min and max age
 
     Code
-      bin_time(occdf = occdf, bins = bins)
+      bin_time(data = data, bins = bins)
     Condition
       Error in `bin_time()`:
       ! Minimum age of occurrence data (-5000) is less than minimum age of bins (0).
@@ -150,7 +150,7 @@
 ---
 
     Code
-      bin_time(occdf = occdf, bins = bins)
+      bin_time(data = data, bins = bins)
     Condition
       Error in `bin_time()`:
       ! Maximum age of occurrence data (5000) surpasses maximum age of bins (540).
@@ -158,7 +158,7 @@
 ---
 
     Code
-      bin_time(occdf = occdf, bins = bins)
+      bin_time(data = data, bins = bins)
     Condition
       Error in `bin_time()`:
       ! `max_ma` can't contain NA values.
@@ -166,28 +166,28 @@
 # bin_time errors with unnamed args
 
     Code
-      bin_time(occdf = test_occdf, test_bins, method = "majority")
+      bin_time(data = test_data, test_bins, method = "majority")
     Condition
       Error in `bin_time()`:
-      ! All arguments must be named (except for "occdf").
+      ! All arguments must be named (except for "data").
       i Currently, there is 1 argument that should be named.
 
 ---
 
     Code
-      bin_time(test_occdf, test_bins, "majority")
+      bin_time(test_data, test_bins, "majority")
     Condition
       Error in `bin_time()`:
-      ! All arguments must be named (except for "occdf").
+      ! All arguments must be named (except for "data").
       i Currently, there are 2 arguments that should be named.
 
 ---
 
     Code
-      bin_time(occdf = test_occdf, bins = test_bins, method = "point", reps = 5, fun = dnorm,
+      bin_time(data = test_data, bins = test_bins, method = "point", reps = 5, fun = dnorm,
         0.5, 0.25)
     Condition
       Error in `bin_time()`:
-      ! All arguments must be named (except for "occdf").
+      ! All arguments must be named (except for "data").
       i Currently, there are 2 arguments that should be named.
 

--- a/tests/testthat/_snaps/group_apply.md
+++ b/tests/testthat/_snaps/group_apply.md
@@ -1,67 +1,67 @@
-# error handling for argument 'occdf'
+# error handling for argument 'data'
 
     Code
       group_apply(group = "cc", fun = nrow)
     Condition
       Error in `group_apply()`:
-      ! `occdf` must be of class <data.frame>, not absent.
+      ! `data` must be of class <data.frame>, not absent.
 
 ---
 
     Code
-      group_apply(occdf = 1, group = "cc", fun = nrow)
+      group_apply(data = 1, group = "cc", fun = nrow)
     Condition
       Error in `group_apply()`:
-      ! `occdf` must be of class <data.frame>, not the number 1.
+      ! `data` must be of class <data.frame>, not the number 1.
 
 ---
 
     Code
-      group_apply(occdf = data.frame(), group = "cc", fun = nrow)
+      group_apply(data = data.frame(), group = "cc", fun = nrow)
     Condition
       Error in `group_apply()`:
-      ! Column "cc" not found in `occdf`.
+      ! Column "cc" not found in `data`.
 
 # group_apply errors with unnamed args
 
     Code
-      group_apply(occdf, group = "cc", nrow)
+      group_apply(data, group = "cc", nrow)
     Condition
       Error in `group_apply()`:
-      ! All arguments must be named (except for "occdf").
+      ! All arguments must be named (except for "data").
       i Currently, there is 1 argument that should be named.
 
 ---
 
     Code
-      group_apply(occdf, "cc", nrow)
+      group_apply(data, "cc", nrow)
     Condition
       Error in `group_apply()`:
-      ! All arguments must be named (except for "occdf").
+      ! All arguments must be named (except for "data").
       i Currently, there are 2 arguments that should be named.
 
 ---
 
     Code
-      group_apply(occdf, "cc", fun = tax_range_time, "family")
+      group_apply(data, "cc", fun = tax_range_time, "family")
     Condition
       Error in `group_apply()`:
-      ! All arguments must be named (except for "occdf").
+      ! All arguments must be named (except for "data").
       i Currently, there are 2 arguments that should be named.
 
 ---
 
     Code
-      group_apply(occdf, "cc", fun = tax_range_time, name = "family")
+      group_apply(data, "cc", fun = tax_range_time, name = "family")
     Condition
       Error in `group_apply()`:
-      ! All arguments must be named (except for "occdf").
+      ! All arguments must be named (except for "data").
       i Currently, there is 1 argument that should be named.
 
 # error handling for argument 'group'
 
     Code
-      group_apply(occdf = occdf, fun = nrow)
+      group_apply(data = data, fun = nrow)
     Condition
       Error in `group_apply()`:
       ! `group` must be a character vector, not absent.
@@ -69,7 +69,7 @@
 ---
 
     Code
-      group_apply(occdf = occdf, group = NULL, fun = nrow)
+      group_apply(data = data, group = NULL, fun = nrow)
     Condition
       Error in `group_apply()`:
       ! `group` must be a character vector, not `NULL`.
@@ -77,15 +77,15 @@
 ---
 
     Code
-      group_apply(occdf = occdf, group = "foo", fun = nrow)
+      group_apply(data = data, group = "foo", fun = nrow)
     Condition
       Error in `group_apply()`:
-      ! Column "foo" not found in `occdf`.
+      ! Column "foo" not found in `data`.
 
 ---
 
     Code
-      group_apply(occdf = occdf, group = 1, fun = nrow)
+      group_apply(data = data, group = 1, fun = nrow)
     Condition
       Error in `group_apply()`:
       ! `group` must be a character vector, not the number 1.
@@ -93,31 +93,31 @@
 ---
 
     Code
-      group_apply(occdf = occdf, group = c("cc", "foobar"), fun = nrow)
+      group_apply(data = data, group = c("cc", "foobar"), fun = nrow)
     Condition
       Error in `group_apply()`:
-      ! Column "foobar" not found in `occdf`.
+      ! Column "foobar" not found in `data`.
 
 ---
 
     Code
-      group_apply(occdf = occdf, group = c("cc", "foobar", "foobar2"), fun = nrow)
+      group_apply(data = data, group = c("cc", "foobar", "foobar2"), fun = nrow)
     Condition
       Error in `group_apply()`:
-      ! Columns "foobar" and "foobar2" not found in `occdf`.
+      ! Columns "foobar" and "foobar2" not found in `data`.
 
 ---
 
     Code
-      group_apply(occdf = occdf, group = c("cc", "foo"), fun = nrow)
+      group_apply(data = data, group = c("cc", "foo"), fun = nrow)
     Condition
       Error in `group_apply()`:
-      ! Column "foo" not found in `occdf`.
+      ! Column "foo" not found in `data`.
 
 # error handling for argument 'fun'
 
     Code
-      group_apply(occdf = occdf, group = "cc", fun = "tax_range_time")
+      group_apply(data = data, group = "cc", fun = "tax_range_time")
     Condition
       Error in `group_apply()`:
       ! `fun` must be a function, not the string "tax_range_time".
@@ -125,7 +125,7 @@
 ---
 
     Code
-      group_apply(occdf = occdf, group = "cc", fun = foobar)
+      group_apply(data = data, group = "cc", fun = foobar)
     Condition
       Error:
       ! object 'foobar' not found
@@ -133,7 +133,7 @@
 ---
 
     Code
-      group_apply(occdf = occdf, group = "cc", fun = tax_range_time, not_an_argument = "test")
+      group_apply(data = data, group = "cc", fun = tax_range_time, not_an_argument = "test")
     Condition
       Error in `group_apply()`:
       ! `not_an_argument` is not a valid argument for the specified function `tax_range_time()`.
@@ -141,8 +141,8 @@
 ---
 
     Code
-      group_apply(occdf = occdf, group = "cc", fun = tax_range_time,
-        not_an_argument1 = "test", not_an_argument2 = "test")
+      group_apply(data = data, group = "cc", fun = tax_range_time, not_an_argument1 = "test",
+        not_an_argument2 = "test")
     Condition
       Error in `group_apply()`:
       ! `not_an_argument1` and `not_an_argument2` are not valid arguments for the specified function `tax_range_time()`.

--- a/tests/testthat/_snaps/look_up.md
+++ b/tests/testthat/_snaps/look_up.md
@@ -4,16 +4,16 @@
       look_up(test_look_up, "early_interval")
     Condition
       Error in `look_up()`:
-      ! All arguments must be named (except for "occdf").
+      ! All arguments must be named (except for "data").
       i Currently, there is 1 argument that should be named.
 
 ---
 
     Code
-      look_up(occdf = test_look_up, "early_interval")
+      look_up(data = test_look_up, "early_interval")
     Condition
       Error in `look_up()`:
-      ! All arguments must be named (except for "occdf").
+      ! All arguments must be named (except for "data").
       i Currently, there is 1 argument that should be named.
 
 ---
@@ -22,7 +22,7 @@
       look_up(test_look_up, "early_interval", "late_interval")
     Condition
       Error in `look_up()`:
-      ! All arguments must be named (except for "occdf").
+      ! All arguments must be named (except for "data").
       i Currently, there are 2 arguments that should be named.
 
 ---
@@ -31,16 +31,16 @@
       look_up(test_look_up, "early_interval", late_interval = "late_interval")
     Condition
       Error in `look_up()`:
-      ! All arguments must be named (except for "occdf").
+      ! All arguments must be named (except for "data").
       i Currently, there is 1 argument that should be named.
 
-# wrong input for argument 'occdf'
+# wrong input for argument 'data'
 
     Code
       look_up(1)
     Condition
       Error in `look_up()`:
-      ! `occdf` must be of class <data.frame>, not the number 1.
+      ! `data` must be of class <data.frame>, not the number 1.
 
 ---
 
@@ -48,7 +48,7 @@
       look_up(NA)
     Condition
       Error in `look_up()`:
-      ! `occdf` must be of class <data.frame>, not `NA`.
+      ! `data` must be of class <data.frame>, not `NA`.
 
 ---
 
@@ -56,36 +56,36 @@
       look_up(NULL)
     Condition
       Error in `look_up()`:
-      ! `occdf` must be of class <data.frame>, not `NULL`.
+      ! `data` must be of class <data.frame>, not `NULL`.
 
 # arguments 'early_interval' and 'late_interval' work
 
     Code
-      look_up(occdf = dat)
+      look_up(data = dat)
     Condition
       Error in `look_up()`:
-      ! Column "early_interval" not found in `occdf`.
+      ! Column "early_interval" not found in `data`.
 
 ---
 
     Code
-      look_up(occdf = dat, early_interval = "early")
+      look_up(data = dat, early_interval = "early")
     Condition
       Error in `look_up()`:
-      ! Column "late_interval" not found in `occdf`.
+      ! Column "late_interval" not found in `data`.
 
 ---
 
     Code
-      look_up(occdf = dat, late_interval = "late")
+      look_up(data = dat, late_interval = "late")
     Condition
       Error in `look_up()`:
-      ! Column "early_interval" not found in `occdf`.
+      ! Column "early_interval" not found in `data`.
 
 ---
 
     Code
-      look_up(occdf = dat, early_interval = 1)
+      look_up(data = dat, early_interval = 1)
     Condition
       Error in `look_up()`:
       ! `early_interval` must be a single string, not the number 1.
@@ -93,7 +93,7 @@
 ---
 
     Code
-      look_up(occdf = dat, early_interval = NA)
+      look_up(data = dat, early_interval = NA)
     Condition
       Error in `look_up()`:
       ! `early_interval` must be a single string, not `NA`.
@@ -101,7 +101,7 @@
 ---
 
     Code
-      look_up(occdf = dat, early_interval = c("a", "b"))
+      look_up(data = dat, early_interval = c("a", "b"))
     Condition
       Error in `look_up()`:
       ! `early_interval` must be a single string, not a character vector.
@@ -109,7 +109,7 @@
 ---
 
     Code
-      look_up(occdf = dat, early_interval = "early", late_interval = 1)
+      look_up(data = dat, early_interval = "early", late_interval = 1)
     Condition
       Error in `look_up()`:
       ! `late_interval` must be a single string, not the number 1.
@@ -117,7 +117,7 @@
 ---
 
     Code
-      look_up(occdf = dat, early_interval = "early", late_interval = NA)
+      look_up(data = dat, early_interval = "early", late_interval = NA)
     Condition
       Error in `look_up()`:
       ! `late_interval` must be a single string, not `NA`.
@@ -125,7 +125,7 @@
 ---
 
     Code
-      look_up(occdf = dat, early_interval = "early", late_interval = c("a", "b"))
+      look_up(data = dat, early_interval = "early", late_interval = c("a", "b"))
     Condition
       Error in `look_up()`:
       ! `late_interval` must be a single string, not a character vector.
@@ -133,7 +133,7 @@
 # argument 'int_key' works
 
     Code
-      look_up(occdf, int_key = 1)
+      look_up(data, int_key = 1)
     Condition
       Error in `look_up()`:
       ! `int_key` must be of class <data.frame>, not the number 1.
@@ -141,7 +141,7 @@
 ---
 
     Code
-      look_up(occdf, int_key = c("a", "b"))
+      look_up(data, int_key = c("a", "b"))
     Condition
       Error in `look_up()`:
       ! `int_key` must be of class <data.frame>, not a character vector.
@@ -149,7 +149,7 @@
 ---
 
     Code
-      look_up(occdf, int_key = data.frame(interval_name = c("Induan", "Asselian"),
+      look_up(data, int_key = data.frame(interval_name = c("Induan", "Asselian"),
       early_stage = c("foo1", "foo2")))
     Condition
       Error in `look_up()`:
@@ -158,7 +158,7 @@
 ---
 
     Code
-      look_up(occdf, int_key = data.frame(interval_name = c("Induan", "Asselian"),
+      look_up(data, int_key = data.frame(interval_name = c("Induan", "Asselian"),
       late_stage = c("foo1", "foo2")))
     Condition
       Error in `look_up()`:
@@ -167,7 +167,7 @@
 ---
 
     Code
-      look_up(occdf, int_key = data.frame(interval_name = c("Induan", "Asselian"),
+      look_up(data, int_key = data.frame(interval_name = c("Induan", "Asselian"),
       early_stage = 1:2, late_stage = c("foo1", "foo2")))
     Condition
       Error in `look_up()`:
@@ -176,7 +176,7 @@
 ---
 
     Code
-      look_up(occdf, int_key = data.frame(interval_name = c("Induan", "Asselian"),
+      look_up(data, int_key = data.frame(interval_name = c("Induan", "Asselian"),
       early_stage = c("foo1", "foo2"), late_stage = c("foo1", "foo2"), max_ma = c("a",
         "b")))
     Condition
@@ -186,7 +186,7 @@
 ---
 
     Code
-      look_up(occdf, int_key = data.frame(interval_name = c("Induan", "Asselian"),
+      look_up(data, int_key = data.frame(interval_name = c("Induan", "Asselian"),
       early_stage = c("foo1", "foo2"), late_stage = c("foo1", "foo2"), min_ma = c("a",
         "b")))
     Condition
@@ -196,7 +196,7 @@
 # argument 'assign_with_GTS' works
 
     Code
-      look_up(occdf, int_key = interval_key, assign_with_GTS = "foo")
+      look_up(data, int_key = interval_key, assign_with_GTS = "foo")
     Condition
       Error in `!assign_with_GTS`:
       ! invalid argument type
@@ -204,7 +204,7 @@
 ---
 
     Code
-      look_up(occdf, assign_with_GTS = FALSE)
+      look_up(data, assign_with_GTS = FALSE)
     Condition
       Error in `look_up()`:
       ! `assign_with_GTS` must be "GTS2020" or "GTS2012" when `int_key = FALSE`.
@@ -212,7 +212,7 @@
 ---
 
     Code
-      look_up(occdf, assign_with_GTS = 1)
+      look_up(data, assign_with_GTS = 1)
     Condition
       Error in `look_up()`:
       ! `assign_with_GTS` must be "GTS2020" or "GTS2012" when `int_key = FALSE`.
@@ -220,7 +220,7 @@
 ---
 
     Code
-      look_up(occdf, assign_with_GTS = "foo")
+      look_up(data, assign_with_GTS = "foo")
     Condition
       Error in `look_up()`:
       ! `assign_with_GTS` must be "GTS2020" or "GTS2012" when `int_key = FALSE`.

--- a/tests/testthat/_snaps/palaeorotate.md
+++ b/tests/testthat/_snaps/palaeorotate.md
@@ -1,142 +1,142 @@
-# arg 'occdf' works
+# arg 'data' works
 
     Code
-      palaeorotate(occdf = 10)
+      palaeorotate(data = 10)
     Condition
       Error in `palaeorotate()`:
-      ! `occdf` must be of class <data.frame>, not the number 10.
+      ! `data` must be of class <data.frame>, not the number 10.
 
 ---
 
     Code
-      palaeorotate(occdf = NA)
+      palaeorotate(data = NA)
     Condition
       Error in `palaeorotate()`:
-      ! `occdf` must be of class <data.frame>, not `NA`.
+      ! `data` must be of class <data.frame>, not `NA`.
 
 ---
 
     Code
-      palaeorotate(occdf = data.frame(lng = 10, lat = 5))
+      palaeorotate(data = data.frame(lng = 10, lat = 5))
     Condition
       Error in `palaeorotate()`:
-      ! Column "age" not found in `occdf`.
+      ! Column "age" not found in `data`.
 
 # palaeorotate errors with unnamed args
 
     Code
-      palaeorotate(occdf, "lng")
+      palaeorotate(data, "lng")
     Condition
       Error in `palaeorotate()`:
-      ! All arguments must be named (except for "occdf").
+      ! All arguments must be named (except for "data").
       i Currently, there is 1 argument that should be named.
 
 ---
 
     Code
-      palaeorotate(occdf = occdf, "lng")
+      palaeorotate(data = data, "lng")
     Condition
       Error in `palaeorotate()`:
-      ! All arguments must be named (except for "occdf").
+      ! All arguments must be named (except for "data").
       i Currently, there is 1 argument that should be named.
 
 ---
 
     Code
-      palaeorotate(occdf, "lng", "lat")
+      palaeorotate(data, "lng", "lat")
     Condition
       Error in `palaeorotate()`:
-      ! All arguments must be named (except for "occdf").
+      ! All arguments must be named (except for "data").
       i Currently, there are 2 arguments that should be named.
 
 ---
 
     Code
-      palaeorotate(occdf, "lng", lat = "lat")
+      palaeorotate(data, "lng", lat = "lat")
     Condition
       Error in `palaeorotate()`:
-      ! All arguments must be named (except for "occdf").
+      ! All arguments must be named (except for "data").
       i Currently, there is 1 argument that should be named.
 
 # input checks for longitude
 
     Code
-      palaeorotate(occdf = data.frame(lng = 210, lat = 40, age = 25))
+      palaeorotate(data = data.frame(lng = 210, lat = 40, age = 25))
     Condition
       Error in `palaeorotate()`:
-      ! All values of column "lng" in `occdf` must be between -180 and 180.
+      ! All values of column "lng" in `data` must be between -180 and 180.
       i Value(s) outside the range: 210.
 
 ---
 
     Code
-      palaeorotate(occdf = data.frame(lng = NA, lat = 40, age = 25))
+      palaeorotate(data = data.frame(lng = NA, lat = 40, age = 25))
     Condition
       Error in `palaeorotate()`:
-      ! Column "lng" in `occdf` must be <numeric>, not <logical>.
+      ! Column "lng" in `data` must be <numeric>, not <logical>.
 
 ---
 
     Code
-      palaeorotate(occdf = data.frame(lng = "a", lat = 40, age = 25))
+      palaeorotate(data = data.frame(lng = "a", lat = 40, age = 25))
     Condition
       Error in `palaeorotate()`:
-      ! Column "lng" in `occdf` must be <numeric>, not <character>.
+      ! Column "lng" in `data` must be <numeric>, not <character>.
 
 # input checks for latitude
 
     Code
-      palaeorotate(occdf = data.frame(lng = 160, lat = 200, age = 25))
+      palaeorotate(data = data.frame(lng = 160, lat = 200, age = 25))
     Condition
       Error in `palaeorotate()`:
-      ! All values of column "lat" in `occdf` must be between -90 and 90.
+      ! All values of column "lat" in `data` must be between -90 and 90.
       i Value(s) outside the range: 200.
 
 ---
 
     Code
-      palaeorotate(occdf = data.frame(lng = 40, lat = NA, age = 25))
+      palaeorotate(data = data.frame(lng = 40, lat = NA, age = 25))
     Condition
       Error in `palaeorotate()`:
-      ! Column "lat" in `occdf` must be <numeric>, not <logical>.
+      ! Column "lat" in `data` must be <numeric>, not <logical>.
 
 ---
 
     Code
-      palaeorotate(occdf = data.frame(lng = 40, lat = "a", age = 25))
+      palaeorotate(data = data.frame(lng = 40, lat = "a", age = 25))
     Condition
       Error in `palaeorotate()`:
-      ! Column "lat" in `occdf` must be <numeric>, not <character>.
+      ! Column "lat" in `data` must be <numeric>, not <character>.
 
 # input checks values for age
 
     Code
-      palaeorotate(occdf = data.frame(lng = 160, lat = 40, age = -1))
+      palaeorotate(data = data.frame(lng = 160, lat = 40, age = -1))
     Condition
       Error in `palaeorotate()`:
-      ! All values of column "age" in `occdf` must be positive.
+      ! All values of column "age" in `data` must be positive.
       i Value(s) outside the range: -1.
 
 ---
 
     Code
-      palaeorotate(occdf = data.frame(lng = 160, lat = 40, age = NA))
+      palaeorotate(data = data.frame(lng = 160, lat = 40, age = NA))
     Condition
       Error in `palaeorotate()`:
-      ! Column "age" in `occdf` must be <numeric>, not <logical>.
+      ! Column "age" in `data` must be <numeric>, not <logical>.
 
 ---
 
     Code
-      palaeorotate(occdf = data.frame(lng = 160, lat = 40, age = "a"))
+      palaeorotate(data = data.frame(lng = 160, lat = 40, age = "a"))
     Condition
       Error in `palaeorotate()`:
-      ! Column "age" in `occdf` must be <numeric>, not <character>.
+      ! Column "age" in `data` must be <numeric>, not <character>.
 
 # arg 'model' works
 
     Code
-      palaeorotate(occdf = occdf, method = "point", model = NA)
+      palaeorotate(data = data, method = "point", model = NA)
     Condition
       Error in `palaeorotate()`:
       ! `model` must be a character vector, not `NA`.
@@ -144,7 +144,7 @@
 ---
 
     Code
-      palaeorotate(occdf = occdf, method = "point", model = character(0))
+      palaeorotate(data = data, method = "point", model = character(0))
     Condition
       Error in `palaeorotate()`:
       ! `model` must select at least one model.
@@ -152,7 +152,7 @@
 ---
 
     Code
-      palaeorotate(occdf = occdf, method = "point", model = "MULLER2022")
+      palaeorotate(data = data, method = "point", model = "MULLER2022")
     Condition
       Error in `palaeorotate()`:
       ! Selected model "MULLER2022" has recently been removed as it is not in a palaeomagnetic reference frame.
@@ -161,7 +161,7 @@
 ---
 
     Code
-      palaeorotate(occdf = occdf, method = "point", model = "GPlates")
+      palaeorotate(data = data, method = "point", model = "GPlates")
     Condition
       Error in `palaeorotate()`:
       ! `model` must be one of "MERDITH2021", "MATTHEWS2016_pmag_ref", "TorsvikCocks2017", "GOLONKA", or "PALEOMAP", not "GPlates".
@@ -169,7 +169,7 @@
 # arg 'method' works
 
     Code
-      palaeorotate(occdf = occdf, method = "foo")
+      palaeorotate(data = data, method = "foo")
     Condition
       Error in `palaeorotate()`:
       ! `method` must be one of "point" or "grid", not "foo".
@@ -177,7 +177,7 @@
 ---
 
     Code
-      palaeorotate(occdf = occdf, method = NA)
+      palaeorotate(data = data, method = NA)
     Condition
       Error in `palaeorotate()`:
       ! `method` must be a single string, not `NA`.
@@ -185,7 +185,7 @@
 ---
 
     Code
-      palaeorotate(occdf = occdf, method = character(0))
+      palaeorotate(data = data, method = character(0))
     Condition
       Error in `palaeorotate()`:
       ! `method` must be a single string, not an empty character vector.
@@ -193,7 +193,7 @@
 ---
 
     Code
-      palaeorotate(occdf = occdf, method = c("point", "grid"))
+      palaeorotate(data = data, method = c("point", "grid"))
     Condition
       Error in `palaeorotate()`:
       ! `method` must be a single string, not a character vector.
@@ -201,7 +201,7 @@
 # arg 'uncertainty' works
 
     Code
-      palaeorotate(occdf = dat, uncertainty = "GOONTHEN")
+      palaeorotate(data = dat, uncertainty = "GOONTHEN")
     Condition
       Error in `palaeorotate()`:
       ! `uncertainty` must be `TRUE` or `FALSE`, not the string "GOONTHEN".
@@ -209,7 +209,7 @@
 ---
 
     Code
-      palaeorotate(occdf = dat, uncertainty = character(0))
+      palaeorotate(data = dat, uncertainty = character(0))
     Condition
       Error in `palaeorotate()`:
       ! `uncertainty` must be `TRUE` or `FALSE`, not an empty character vector.
@@ -217,7 +217,7 @@
 ---
 
     Code
-      palaeorotate(occdf = dat, uncertainty = 1)
+      palaeorotate(data = dat, uncertainty = 1)
     Condition
       Error in `palaeorotate()`:
       ! `uncertainty` must be `TRUE` or `FALSE`, not the number 1.
@@ -225,7 +225,7 @@
 # arg 'round' works
 
     Code
-      palaeorotate(occdf = occdf, round = TRUE)
+      palaeorotate(data = data, round = TRUE)
     Condition
       Error in `palaeorotate()`:
       ! `round` must be a whole number or `NULL`, not `TRUE`.
@@ -233,7 +233,7 @@
 ---
 
     Code
-      palaeorotate(occdf = occdf, round = NA)
+      palaeorotate(data = data, round = NA)
     Condition
       Error in `palaeorotate()`:
       ! `round` must be a whole number or `NULL`, not `NA`.
@@ -241,7 +241,7 @@
 ---
 
     Code
-      palaeorotate(occdf = occdf, round = numeric(0))
+      palaeorotate(data = data, round = numeric(0))
     Condition
       Error in `palaeorotate()`:
       ! `round` must be a whole number or `NULL`, not an empty numeric vector.
@@ -249,7 +249,7 @@
 ---
 
     Code
-      palaeorotate(occdf = occdf, round = 1:2)
+      palaeorotate(data = data, round = 1:2)
     Condition
       Error in `palaeorotate()`:
       ! `round` must be a whole number or `NULL`, not an integer vector.
@@ -257,7 +257,7 @@
 # good error message if GPlates or Zenodo are not available
 
     Code
-      palaeorotate(occdf = occdf, model = "PALEOMAP")
+      palaeorotate(data = data, model = "PALEOMAP")
     Condition
       Error in `palaeorotate()`:
       ! GPlates Web Service is not available.
@@ -266,7 +266,7 @@
 ---
 
     Code
-      palaeorotate(occdf = occdf, model = "PALEOMAP", method = "grid")
+      palaeorotate(data = data, model = "PALEOMAP", method = "grid")
     Condition
       Error in `palaeorotate()`:
       ! Zenodo is not available.

--- a/tests/testthat/_snaps/tax_certainty.md
+++ b/tests/testthat/_snaps/tax_certainty.md
@@ -1,10 +1,10 @@
 # throws error for missing required arguments
 
     Code
-      tax_certainty(taxdf = 1, name = "foo")
+      tax_certainty(data = 1, name = "foo")
     Condition
       Error in `tax_certainty()`:
-      ! `taxdf` must be of class <data.frame>, not the number 1.
+      ! `data` must be of class <data.frame>, not the number 1.
 
 ---
 
@@ -12,12 +12,12 @@
       tax_certainty()
     Condition
       Error in `tax_certainty()`:
-      ! `taxdf` must be of class <data.frame>, not absent.
+      ! `data` must be of class <data.frame>, not absent.
 
 ---
 
     Code
-      tax_certainty(taxdf = tetrapods)
+      tax_certainty(data = tetrapods)
     Condition
       Error in `tax_certainty()`:
       ! `name` must be a single string, not absent.
@@ -25,59 +25,59 @@
 # tax_certainty errors with unnamed args
 
     Code
-      tax_certainty(occdf, "identified_name")
+      tax_certainty(data, "identified_name")
     Condition
       Error in `tax_certainty()`:
-      ! All arguments must be named (except for "taxdf").
+      ! All arguments must be named (except for "data").
       i Currently, there is 1 argument that should be named.
 
 ---
 
     Code
-      tax_certainty(taxdf = occdf, "identified_name")
+      tax_certainty(data = data, "identified_name")
     Condition
       Error in `tax_certainty()`:
-      ! All arguments must be named (except for "taxdf").
+      ! All arguments must be named (except for "data").
       i Currently, there is 1 argument that should be named.
 
 ---
 
     Code
-      tax_certainty(occdf, "identified_name", NULL)
+      tax_certainty(data, "identified_name", NULL)
     Condition
       Error in `tax_certainty()`:
-      ! All arguments must be named (except for "taxdf").
+      ! All arguments must be named (except for "data").
       i Currently, there are 2 arguments that should be named.
 
 ---
 
     Code
-      tax_certainty(occdf, "identified_name", terms = NULL)
+      tax_certainty(data, "identified_name", terms = NULL)
     Condition
       Error in `tax_certainty()`:
-      ! All arguments must be named (except for "taxdf").
+      ! All arguments must be named (except for "data").
       i Currently, there is 1 argument that should be named.
 
 # tax_certainty() basic behavior
 
     Code
-      tax_certainty(taxdf = data.frame(), name = "identified_name")
+      tax_certainty(data = data.frame(), name = "identified_name")
     Condition
       Error in `tax_certainty()`:
-      ! Column "identified_name" not found in `taxdf`.
+      ! Column "identified_name" not found in `data`.
 
 # arg 'name' works
 
     Code
-      tax_certainty(taxdf = occdf, name = "foo")
+      tax_certainty(data = data, name = "foo")
     Condition
       Error in `tax_certainty()`:
-      ! Column "foo" not found in `taxdf`.
+      ! Column "foo" not found in `data`.
 
 ---
 
     Code
-      tax_certainty(taxdf = occdf, name = NULL)
+      tax_certainty(data = data, name = NULL)
     Condition
       Error in `tax_certainty()`:
       ! `name` must be a single string, not `NULL`.
@@ -85,7 +85,7 @@
 # arg 'terms' works
 
     Code
-      tax_certainty(taxdf = occdf, name = "identified_name", terms = 1)
+      tax_certainty(data = data, name = "identified_name", terms = 1)
     Condition
       Error in `tax_certainty()`:
       ! `terms` must be of class <list> or `NULL`, not the number 1.
@@ -93,7 +93,7 @@
 # arg 'append' works
 
     Code
-      tax_certainty(taxdf = occdf, name = "identified_name", append = 1)
+      tax_certainty(data = data, name = "identified_name", append = 1)
     Condition
       Error in `tax_certainty()`:
       ! `append` must be `TRUE` or `FALSE`, not the number 1.
@@ -101,7 +101,7 @@
 ---
 
     Code
-      tax_certainty(taxdf = occdf, name = "identified_name", append = NA)
+      tax_certainty(data = data, name = "identified_name", append = NA)
     Condition
       Error in `tax_certainty()`:
       ! `append` must be `TRUE` or `FALSE`, not `NA`.

--- a/tests/testthat/_snaps/tax_check.md
+++ b/tests/testthat/_snaps/tax_check.md
@@ -23,7 +23,7 @@
       tax_check(data.frame())
     Condition
       Error in `tax_check()`:
-      ! Column "genus" not found in `taxdf`.
+      ! Column "genus" not found in `data`.
 
 ---
 
@@ -31,7 +31,7 @@
       tax_check(1)
     Condition
       Error in `tax_check()`:
-      ! `taxdf` must be of class <data.frame>, not the number 1.
+      ! `data` must be of class <data.frame>, not the number 1.
 
 ---
 
@@ -39,7 +39,7 @@
       tax_check(data.frame(genus = c(NA, "")))
     Condition
       Error in `tax_check()`:
-      ! Column "genus" in `taxdf` must have at least one entry that is not NA or empty.
+      ! Column "genus" in `data` must have at least one entry that is not NA or empty.
 
 # tax_check errors with unnamed args
 
@@ -47,16 +47,16 @@
       tax_check(dat, "genus")
     Condition
       Error in `tax_check()`:
-      ! All arguments must be named (except for "taxdf").
+      ! All arguments must be named (except for "data").
       i Currently, there is 1 argument that should be named.
 
 ---
 
     Code
-      tax_check(taxdf = dat, "genus")
+      tax_check(data = dat, "genus")
     Condition
       Error in `tax_check()`:
-      ! All arguments must be named (except for "taxdf").
+      ! All arguments must be named (except for "data").
       i Currently, there is 1 argument that should be named.
 
 ---
@@ -65,7 +65,7 @@
       tax_check(dat, "genus", NULL)
     Condition
       Error in `tax_check()`:
-      ! All arguments must be named (except for "taxdf").
+      ! All arguments must be named (except for "data").
       i Currently, there are 2 arguments that should be named.
 
 ---
@@ -74,7 +74,7 @@
       tax_check(dat, "genus", group = NULL)
     Condition
       Error in `tax_check()`:
-      ! All arguments must be named (except for "taxdf").
+      ! All arguments must be named (except for "data").
       i Currently, there is 1 argument that should be named.
 
 # arg 'name' works
@@ -83,7 +83,7 @@
       tax_check(dat)
     Condition
       Error in `tax_check()`:
-      ! Column "genus" not found in `taxdf`.
+      ! Column "genus" not found in `data`.
 
 ---
 
@@ -91,7 +91,7 @@
       tax_check(dat, name = "nonexistent")
     Condition
       Error in `tax_check()`:
-      ! Column "nonexistent" not found in `taxdf`.
+      ! Column "nonexistent" not found in `data`.
 
 ---
 
@@ -123,7 +123,7 @@
       tax_check(dat, name = "")
     Condition
       Error in `tax_check()`:
-      ! Column "" not found in `taxdf`.
+      ! Column "" not found in `data`.
 
 # arg 'group' works
 
@@ -150,7 +150,7 @@
       tax_check(dat, group = "nonexistent")
     Condition
       Error in `tax_check()`:
-      ! Column "nonexistent" not found in `taxdf`.
+      ! Column "nonexistent" not found in `data`.
 
 ---
 
@@ -174,7 +174,7 @@
       tax_check(dat, group = "")
     Condition
       Error in `tax_check()`:
-      ! Column "" not found in `taxdf`.
+      ! Column "" not found in `data`.
 
 # arg 'dis' works
 

--- a/tests/testthat/_snaps/tax_expand_lat.md
+++ b/tests/testthat/_snaps/tax_expand_lat.md
@@ -1,15 +1,15 @@
 # basic behavior works
 
     Code
-      tax_expand_lat(taxdf = 5)
+      tax_expand_lat(data = 5)
     Condition
       Error in `tax_expand_lat()`:
-      ! `taxdf` must be of class <data.frame>, not the number 5.
+      ! `data` must be of class <data.frame>, not the number 5.
 
 ---
 
     Code
-      tax_expand_lat(taxdf)
+      tax_expand_lat(data)
     Condition
       Error in `tax_expand_lat()`:
       ! `bins` must be of class <data.frame>, not absent.
@@ -17,7 +17,7 @@
 ---
 
     Code
-      tax_expand_lat(taxdf, bins = 1)
+      tax_expand_lat(data, bins = 1)
     Condition
       Error in `tax_expand_lat()`:
       ! `bins` must be of class <data.frame>, not the number 1.
@@ -25,81 +25,81 @@
 ---
 
     Code
-      tax_expand_lat(taxdf, bins = bins, max_lat = "lat")
+      tax_expand_lat(data, bins = bins, max_lat = "lat")
     Condition
       Error in `tax_expand_lat()`:
-      ! Column "lat" not found in `taxdf`.
+      ! Column "lat" not found in `data`.
 
 ---
 
     Code
-      tax_expand_lat(taxdf, bins = bins, min_lat = "lat")
+      tax_expand_lat(data, bins = bins, min_lat = "lat")
     Condition
       Error in `tax_expand_lat()`:
-      ! Column "lat" not found in `taxdf`.
+      ! Column "lat" not found in `data`.
 
 ---
 
     Code
-      tax_expand_lat(taxdf = data.frame(name = c("A", "B", "C"), max_lat = c(92, 20,
+      tax_expand_lat(data = data.frame(name = c("A", "B", "C"), max_lat = c(92, 20,
         -10), min_lat = c(20, -40, -60)), bins = bins)
     Condition
       Error in `tax_expand_lat()`:
-      ! All values of column "max_lat" in `taxdf` must be between -90 and 90.
+      ! All values of column "max_lat" in `data` must be between -90 and 90.
       i Value(s) outside the range: 92.
 
 ---
 
     Code
-      tax_expand_lat(taxdf = data.frame(name = c("A", "B", "C"), max_lat = c(60, 20,
+      tax_expand_lat(data = data.frame(name = c("A", "B", "C"), max_lat = c(60, 20,
         -10), min_lat = c(-92, -40, -60)), bins = bins)
     Condition
       Error in `tax_expand_lat()`:
-      ! All values of column "min_lat" in `taxdf` must be between -90 and 90.
+      ! All values of column "min_lat" in `data` must be between -90 and 90.
       i Value(s) outside the range: -92.
 
 ---
 
     Code
-      tax_expand_lat(taxdf = data.frame(name = "a", max_lat = 91:100, min_lat = 1),
+      tax_expand_lat(data = data.frame(name = "a", max_lat = 91:100, min_lat = 1),
       bins = bins)
     Condition
       Error in `tax_expand_lat()`:
-      ! All values of column "max_lat" in `taxdf` must be between -90 and 90.
+      ! All values of column "max_lat" in `data` must be between -90 and 90.
       i Value(s) outside the range (first 5): 91, 92, 93, 94, 95.
 
 ---
 
     Code
-      tax_expand_lat(taxdf = data.frame(name = "a", max_lat = 1, min_lat = 91:100),
+      tax_expand_lat(data = data.frame(name = "a", max_lat = 1, min_lat = 91:100),
       bins = bins)
     Condition
       Error in `tax_expand_lat()`:
-      ! All values of column "min_lat" in `taxdf` must be between -90 and 90.
+      ! All values of column "min_lat" in `data` must be between -90 and 90.
       i Value(s) outside the range (first 5): 91, 92, 93, 94, 95.
 
 ---
 
     Code
-      tax_expand_lat(taxdf = data.frame(name = c("A", "B", "C"), max_lat = c("60",
+      tax_expand_lat(data = data.frame(name = c("A", "B", "C"), max_lat = c("60",
         "20", "-10"), min_lat = c(-90, -40, -60)), bins = bins)
     Condition
       Error in `tax_expand_lat()`:
-      ! Column "max_lat" in `taxdf` must be <numeric>, not <character>.
+      ! Column "max_lat" in `data` must be <numeric>, not <character>.
 
 ---
 
     Code
-      tax_expand_lat(taxdf = data.frame(name = c("A", "B", "C"), max_lat = c(60, 20,
+      tax_expand_lat(data = data.frame(name = c("A", "B", "C"), max_lat = c(60, 20,
         -10), min_lat = c("20", -40, -60)), bins = bins)
     Condition
       Error in `tax_expand_lat()`:
-      ! Column "min_lat" in `taxdf` must be <numeric>, not <character>.
+      ! Column "min_lat" in `data` must be <numeric>, not <character>.
 
 ---
 
     Code
-      tax_expand_lat(taxdf = data.frame(name = c("A", "B", "C"), max_lat = c(60, 20,
+      tax_expand_lat(data = data.frame(name = c("A", "B", "C"), max_lat = c(60, 20,
         -10), min_lat = c(72, -40, -60)), bins = bins)
     Condition
       Error in `tax_expand_lat()`:
@@ -109,7 +109,7 @@
 ---
 
     Code
-      tax_expand_lat(taxdf = data.frame(name = "a", max_lat = c(90, 1:10), min_lat = c(
+      tax_expand_lat(data = data.frame(name = "a", max_lat = c(90, 1:10), min_lat = c(
         72, 21:30)), bins = bins)
     Condition
       Error in `tax_expand_lat()`:
@@ -119,16 +119,16 @@
 ---
 
     Code
-      tax_expand_lat(taxdf = data.frame(name = c("A", "A", "C"), max_lat = c(60, 60,
+      tax_expand_lat(data = data.frame(name = c("A", "A", "C"), max_lat = c(60, 60,
         -10), min_lat = c(20, 20, -60)), bins = bins)
     Condition
       Error in `tax_expand_lat()`:
-      ! `taxdf` must not have duplicated rows.
+      ! `data` must not have duplicated rows.
 
 ---
 
     Code
-      tax_expand_lat(taxdf = taxdf, bins = bins)
+      tax_expand_lat(data = data, bins = bins)
     Condition
       Error in `tax_expand_lat()`:
       ! Column "bin" not found in `bins`.
@@ -136,50 +136,50 @@
 # tax_expand_lat errors with unnamed args
 
     Code
-      tax_expand_lat(taxdf, bins)
+      tax_expand_lat(data, bins)
     Condition
       Error in `tax_expand_lat()`:
-      ! All arguments must be named (except for "taxdf").
+      ! All arguments must be named (except for "data").
       i Currently, there is 1 argument that should be named.
 
 ---
 
     Code
-      tax_expand_lat(taxdf, bins, "max_lat")
+      tax_expand_lat(data, bins, "max_lat")
     Condition
       Error in `tax_expand_lat()`:
-      ! All arguments must be named (except for "taxdf").
+      ! All arguments must be named (except for "data").
       i Currently, there are 2 arguments that should be named.
 
 ---
 
     Code
-      tax_expand_lat(taxdf, bins, max_lat = "max_lat")
+      tax_expand_lat(data, bins, max_lat = "max_lat")
     Condition
       Error in `tax_expand_lat()`:
-      ! All arguments must be named (except for "taxdf").
+      ! All arguments must be named (except for "data").
       i Currently, there is 1 argument that should be named.
 
 # args 'min_lat' and 'max_lat' work
 
     Code
-      tax_expand_lat(taxdf = taxdf, bins = bins)
+      tax_expand_lat(data = data, bins = bins)
     Condition
       Error in `tax_expand_lat()`:
-      ! Column "max_lat" not found in `taxdf`.
+      ! Column "max_lat" not found in `data`.
 
 ---
 
     Code
-      tax_expand_lat(taxdf = taxdf, bins = bins, max_lat = "nonexistent")
+      tax_expand_lat(data = data, bins = bins, max_lat = "nonexistent")
     Condition
       Error in `tax_expand_lat()`:
-      ! Column "nonexistent" not found in `taxdf`.
+      ! Column "nonexistent" not found in `data`.
 
 ---
 
     Code
-      tax_expand_lat(taxdf = taxdf, bins = bins, max_lat = NULL)
+      tax_expand_lat(data = data, bins = bins, max_lat = NULL)
     Condition
       Error in `tax_expand_lat()`:
       ! `max_lat` must be a single string, not `NULL`.
@@ -187,7 +187,7 @@
 ---
 
     Code
-      tax_expand_lat(taxdf = taxdf, bins = bins, max_lat = character(0))
+      tax_expand_lat(data = data, bins = bins, max_lat = character(0))
     Condition
       Error in `tax_expand_lat()`:
       ! `max_lat` must be a single string, not an empty character vector.
@@ -195,7 +195,7 @@
 ---
 
     Code
-      tax_expand_lat(taxdf = taxdf, bins = bins, max_lat = NA)
+      tax_expand_lat(data = data, bins = bins, max_lat = NA)
     Condition
       Error in `tax_expand_lat()`:
       ! `max_lat` must be a single string, not `NA`.
@@ -203,7 +203,7 @@
 ---
 
     Code
-      tax_expand_lat(taxdf = taxdf, bins = bins, max_lat = c("a", "b"))
+      tax_expand_lat(data = data, bins = bins, max_lat = c("a", "b"))
     Condition
       Error in `tax_expand_lat()`:
       ! `max_lat` must be a single string, not a character vector.
@@ -211,15 +211,15 @@
 ---
 
     Code
-      tax_expand_lat(taxdf = taxdf, bins = bins, min_lat = "nonexistent")
+      tax_expand_lat(data = data, bins = bins, min_lat = "nonexistent")
     Condition
       Error in `tax_expand_lat()`:
-      ! Column "nonexistent" not found in `taxdf`.
+      ! Column "nonexistent" not found in `data`.
 
 ---
 
     Code
-      tax_expand_lat(taxdf = taxdf, bins = bins, min_lat = NULL)
+      tax_expand_lat(data = data, bins = bins, min_lat = NULL)
     Condition
       Error in `tax_expand_lat()`:
       ! `min_lat` must be a single string, not `NULL`.
@@ -227,7 +227,7 @@
 ---
 
     Code
-      tax_expand_lat(taxdf = taxdf, bins = bins, min_lat = character(0))
+      tax_expand_lat(data = data, bins = bins, min_lat = character(0))
     Condition
       Error in `tax_expand_lat()`:
       ! `min_lat` must be a single string, not an empty character vector.
@@ -235,7 +235,7 @@
 ---
 
     Code
-      tax_expand_lat(taxdf = taxdf, bins = bins, min_lat = NA)
+      tax_expand_lat(data = data, bins = bins, min_lat = NA)
     Condition
       Error in `tax_expand_lat()`:
       ! `min_lat` must be a single string, not `NA`.
@@ -243,7 +243,7 @@
 ---
 
     Code
-      tax_expand_lat(taxdf = taxdf, bins = bins, min_lat = c("a", "b"))
+      tax_expand_lat(data = data, bins = bins, min_lat = c("a", "b"))
     Condition
       Error in `tax_expand_lat()`:
       ! `min_lat` must be a single string, not a character vector.

--- a/tests/testthat/_snaps/tax_expand_time.md
+++ b/tests/testthat/_snaps/tax_expand_time.md
@@ -4,7 +4,7 @@
       tax_expand_time(data.frame())
     Condition
       Error in `tax_expand_time()`:
-      ! Column "max_ma" not found in `taxdf`.
+      ! Column "max_ma" not found in `data`.
 
 ---
 
@@ -12,7 +12,7 @@
       tax_expand_time(1)
     Condition
       Error in `tax_expand_time()`:
-      ! `taxdf` must be of class <data.frame>, not the number 1.
+      ! `data` must be of class <data.frame>, not the number 1.
 
 ---
 
@@ -20,7 +20,7 @@
       tax_expand_time(NULL)
     Condition
       Error in `tax_expand_time()`:
-      ! `taxdf` must be of class <data.frame>, not `NULL`.
+      ! `data` must be of class <data.frame>, not `NULL`.
 
 ---
 
@@ -28,74 +28,74 @@
       tax_expand_time()
     Condition
       Error in `tax_expand_time()`:
-      ! `taxdf` must be of class <data.frame>, not absent.
+      ! `data` must be of class <data.frame>, not absent.
 
 # tax_expand_time errors with unnamed args
 
     Code
-      tax_expand_time(taxdf, "max_ma")
+      tax_expand_time(data, "max_ma")
     Condition
       Error in `tax_expand_time()`:
-      ! All arguments must be named (except for "taxdf").
+      ! All arguments must be named (except for "data").
       i Currently, there is 1 argument that should be named.
 
 ---
 
     Code
-      tax_expand_time(taxdf, "max_ma")
+      tax_expand_time(data, "max_ma")
     Condition
       Error in `tax_expand_time()`:
-      ! All arguments must be named (except for "taxdf").
+      ! All arguments must be named (except for "data").
       i Currently, there is 1 argument that should be named.
 
 ---
 
     Code
-      tax_expand_time(taxdf, "max_ma", "min_ma")
+      tax_expand_time(data, "max_ma", "min_ma")
     Condition
       Error in `tax_expand_time()`:
-      ! All arguments must be named (except for "taxdf").
+      ! All arguments must be named (except for "data").
       i Currently, there are 2 arguments that should be named.
 
 ---
 
     Code
-      tax_expand_time(taxdf, "max_ma", min_ma = "min_ma")
+      tax_expand_time(data, "max_ma", min_ma = "min_ma")
     Condition
       Error in `tax_expand_time()`:
-      ! All arguments must be named (except for "taxdf").
+      ! All arguments must be named (except for "data").
       i Currently, there is 1 argument that should be named.
 
 # rows must be unique
 
     Code
-      tax_expand_time(taxdf)
+      tax_expand_time(data)
     Condition
       Error in `tax_expand_time()`:
-      ! `taxdf` must not have duplicated rows.
+      ! `data` must not have duplicated rows.
 
 # ages must be positive
 
     Code
-      tax_expand_time(taxdf)
+      tax_expand_time(data)
     Condition
       Error in `tax_expand_time()`:
-      ! All values of column "min_ma" in `taxdf` must be positive.
+      ! All values of column "min_ma" in `data` must be positive.
       i Value(s) outside the range: -20.
 
 # max ages must be larger than or equal to min ages
 
     Code
-      tax_expand_time(taxdf)
+      tax_expand_time(data)
     Condition
       Error in `tax_expand_time()`:
       ! Maximum age must be larger than or equal to minimum age.
-      i Row(s) of `taxdf` where "max_ma" is smaller than "min_ma": 3.
+      i Row(s) of `data` where "max_ma" is smaller than "min_ma": 3.
 
 # arg 'bins' works
 
     Code
-      tax_expand_time(taxdf, bins = data.frame())
+      tax_expand_time(data, bins = data.frame())
     Condition
       Error in `tax_expand_time()`:
       ! Column "bin" not found in `bins`.
@@ -103,7 +103,7 @@
 ---
 
     Code
-      tax_expand_time(taxdf, bins = 1)
+      tax_expand_time(data, bins = 1)
     Condition
       Error in `tax_expand_time()`:
       ! `bins` must be of class <data.frame>, not the number 1.
@@ -111,7 +111,7 @@
 ---
 
     Code
-      tax_expand_time(taxdf, bins = NA)
+      tax_expand_time(data, bins = NA)
     Condition
       Error in `tax_expand_time()`:
       ! `bins` must be of class <data.frame>, not `NA`.
@@ -119,23 +119,23 @@
 # args 'max_ma' and 'min_ma' work
 
     Code
-      tax_expand_time(taxdf, bins = bins)
+      tax_expand_time(data, bins = bins)
     Condition
       Error in `tax_expand_time()`:
-      ! Column "max_ma" not found in `taxdf`.
+      ! Column "max_ma" not found in `data`.
 
 ---
 
     Code
-      tax_expand_time(taxdf, bins = bins, max_ma = "nonexistent", min_ma = "lad")
+      tax_expand_time(data, bins = bins, max_ma = "nonexistent", min_ma = "lad")
     Condition
       Error in `tax_expand_time()`:
-      ! Column "nonexistent" not found in `taxdf`.
+      ! Column "nonexistent" not found in `data`.
 
 ---
 
     Code
-      tax_expand_time(taxdf, bins = bins, max_ma = NULL, min_ma = "lad")
+      tax_expand_time(data, bins = bins, max_ma = NULL, min_ma = "lad")
     Condition
       Error in `tax_expand_time()`:
       ! `max_ma` must be a single string, not `NULL`.
@@ -143,7 +143,7 @@
 ---
 
     Code
-      tax_expand_time(taxdf, bins = bins, max_ma = character(0), min_ma = "lad")
+      tax_expand_time(data, bins = bins, max_ma = character(0), min_ma = "lad")
     Condition
       Error in `tax_expand_time()`:
       ! `max_ma` must be a single string, not an empty character vector.
@@ -151,7 +151,7 @@
 ---
 
     Code
-      tax_expand_time(taxdf, bins = bins, max_ma = NA, min_ma = "lad")
+      tax_expand_time(data, bins = bins, max_ma = NA, min_ma = "lad")
     Condition
       Error in `tax_expand_time()`:
       ! `max_ma` must be a single string, not `NA`.
@@ -159,7 +159,7 @@
 ---
 
     Code
-      tax_expand_time(taxdf, bins = bins, max_ma = c("a", "b"), min_ma = "lad")
+      tax_expand_time(data, bins = bins, max_ma = c("a", "b"), min_ma = "lad")
     Condition
       Error in `tax_expand_time()`:
       ! `max_ma` must be a single string, not a character vector.
@@ -167,15 +167,15 @@
 ---
 
     Code
-      tax_expand_time(taxdf, bins = bins, max_ma = "fad", min_ma = "nonexistent")
+      tax_expand_time(data, bins = bins, max_ma = "fad", min_ma = "nonexistent")
     Condition
       Error in `tax_expand_time()`:
-      ! Column "nonexistent" not found in `taxdf`.
+      ! Column "nonexistent" not found in `data`.
 
 ---
 
     Code
-      tax_expand_time(taxdf, bins = bins, max_ma = "fad", min_ma = NULL)
+      tax_expand_time(data, bins = bins, max_ma = "fad", min_ma = NULL)
     Condition
       Error in `tax_expand_time()`:
       ! `min_ma` must be a single string, not `NULL`.
@@ -183,7 +183,7 @@
 ---
 
     Code
-      tax_expand_time(taxdf, bins = bins, max_ma = "fad", min_ma = character(0))
+      tax_expand_time(data, bins = bins, max_ma = "fad", min_ma = character(0))
     Condition
       Error in `tax_expand_time()`:
       ! `min_ma` must be a single string, not an empty character vector.
@@ -191,7 +191,7 @@
 ---
 
     Code
-      tax_expand_time(taxdf, bins = bins, max_ma = "fad", min_ma = NA)
+      tax_expand_time(data, bins = bins, max_ma = "fad", min_ma = NA)
     Condition
       Error in `tax_expand_time()`:
       ! `min_ma` must be a single string, not `NA`.
@@ -199,7 +199,7 @@
 ---
 
     Code
-      tax_expand_time(taxdf, bins = bins, max_ma = "fad", min_ma = c("a", "b"))
+      tax_expand_time(data, bins = bins, max_ma = "fad", min_ma = c("a", "b"))
     Condition
       Error in `tax_expand_time()`:
       ! `min_ma` must be a single string, not a character vector.
@@ -207,7 +207,7 @@
 # arg 'scale' works
 
     Code
-      tax_expand_time(taxdf, scale = "foo")
+      tax_expand_time(data, scale = "foo")
     Condition
       Error:
       ! `scale` must match a built-in or Macrostrat time scale.
@@ -215,7 +215,7 @@
 ---
 
     Code
-      tax_expand_time(taxdf, scale = character(0))
+      tax_expand_time(data, scale = character(0))
     Condition
       Error in `tax_expand_time()`:
       ! `scale` must be a single string, not an empty character vector.
@@ -223,7 +223,7 @@
 ---
 
     Code
-      tax_expand_time(taxdf, scale = NULL)
+      tax_expand_time(data, scale = NULL)
     Condition
       Error in `tax_expand_time()`:
       ! `scale` must be a single string, not `NULL`.
@@ -231,7 +231,7 @@
 ---
 
     Code
-      tax_expand_time(taxdf, scale = 1)
+      tax_expand_time(data, scale = 1)
     Condition
       Error in `tax_expand_time()`:
       ! `scale` must be a single string, not the number 1.
@@ -239,7 +239,7 @@
 ---
 
     Code
-      tax_expand_time(taxdf, scale = NA)
+      tax_expand_time(data, scale = NA)
     Condition
       Error in `tax_expand_time()`:
       ! `scale` must be a single string, not `NA`.
@@ -247,7 +247,7 @@
 # arg 'rank' works
 
     Code
-      tax_expand_time(taxdf, rank = c("eon", "period"))
+      tax_expand_time(data, rank = c("eon", "period"))
     Condition
       Error in `tax_expand_time()`:
       ! `rank` must be a single string, not a character vector.
@@ -255,7 +255,7 @@
 ---
 
     Code
-      tax_expand_time(taxdf, rank = "foo")
+      tax_expand_time(data, rank = "foo")
     Condition
       Error in `tax_expand_time()`:
       ! `rank` must be one of "stage", "epoch", "period", "era", or "eon", not "foo".
@@ -263,7 +263,7 @@
 ---
 
     Code
-      tax_expand_time(taxdf, rank = character(0))
+      tax_expand_time(data, rank = character(0))
     Condition
       Error in `tax_expand_time()`:
       ! `rank` must be a single string, not an empty character vector.
@@ -271,7 +271,7 @@
 ---
 
     Code
-      tax_expand_time(taxdf, rank = NULL)
+      tax_expand_time(data, rank = NULL)
     Condition
       Error in `tax_expand_time()`:
       ! `rank` must be a single string, not `NULL`.
@@ -279,7 +279,7 @@
 ---
 
     Code
-      tax_expand_time(taxdf, rank = 1)
+      tax_expand_time(data, rank = 1)
     Condition
       Error in `tax_expand_time()`:
       ! `rank` must be a single string, not the number 1.
@@ -287,7 +287,7 @@
 ---
 
     Code
-      tax_expand_time(taxdf, rank = NA)
+      tax_expand_time(data, rank = NA)
     Condition
       Error in `tax_expand_time()`:
       ! `rank` must be a single string, not `NA`.
@@ -295,7 +295,7 @@
 # arg 'ext_orig' works
 
     Code
-      tax_expand_time(taxdf, ext_orig = "foo")
+      tax_expand_time(data, ext_orig = "foo")
     Condition
       Error in `tax_expand_time()`:
       ! `ext_orig` must be `TRUE` or `FALSE`, not the string "foo".
@@ -303,7 +303,7 @@
 ---
 
     Code
-      tax_expand_time(taxdf, ext_orig = logical(0))
+      tax_expand_time(data, ext_orig = logical(0))
     Condition
       Error in `tax_expand_time()`:
       ! `ext_orig` must be `TRUE` or `FALSE`, not an empty logical vector.
@@ -311,7 +311,7 @@
 ---
 
     Code
-      tax_expand_time(taxdf, ext_orig = NULL)
+      tax_expand_time(data, ext_orig = NULL)
     Condition
       Error in `tax_expand_time()`:
       ! `ext_orig` must be `TRUE` or `FALSE`, not `NULL`.
@@ -319,7 +319,7 @@
 ---
 
     Code
-      tax_expand_time(taxdf, ext_orig = 1)
+      tax_expand_time(data, ext_orig = 1)
     Condition
       Error in `tax_expand_time()`:
       ! `ext_orig` must be `TRUE` or `FALSE`, not the number 1.
@@ -327,7 +327,7 @@
 ---
 
     Code
-      tax_expand_time(taxdf, ext_orig = NA)
+      tax_expand_time(data, ext_orig = NA)
     Condition
       Error in `tax_expand_time()`:
       ! `ext_orig` must be `TRUE` or `FALSE`, not `NA`.

--- a/tests/testthat/_snaps/tax_range_space.md
+++ b/tests/testthat/_snaps/tax_range_space.md
@@ -1,77 +1,77 @@
 # tax_range_space() works
 
     Code
-      tax_range_space(occdf = data.frame())
+      tax_range_space(data = data.frame())
     Condition
       Error in `tax_range_space()`:
-      ! Column "genus" not found in `occdf`.
+      ! Column "genus" not found in `data`.
 
 ---
 
     Code
-      tax_range_space(occdf = NA)
+      tax_range_space(data = NA)
     Condition
       Error in `tax_range_space()`:
-      ! `occdf` must be of class <data.frame>, not `NA`.
+      ! `data` must be of class <data.frame>, not `NA`.
 
 ---
 
     Code
-      tax_range_space(occdf = "a")
+      tax_range_space(data = "a")
     Condition
       Error in `tax_range_space()`:
-      ! `occdf` must be of class <data.frame>, not the string "a".
+      ! `data` must be of class <data.frame>, not the string "a".
 
 # tax_range_space errors with unnamed args
 
     Code
-      tax_range_space(occdf, "genus")
+      tax_range_space(data, "genus")
     Condition
       Error in `tax_range_space()`:
-      ! All arguments must be named (except for "occdf").
+      ! All arguments must be named (except for "data").
       i Currently, there is 1 argument that should be named.
 
 ---
 
     Code
-      tax_range_space(occdf, "genus", "lng")
+      tax_range_space(data, "genus", "lng")
     Condition
       Error in `tax_range_space()`:
-      ! All arguments must be named (except for "occdf").
+      ! All arguments must be named (except for "data").
       i Currently, there are 2 arguments that should be named.
 
 ---
 
     Code
-      tax_range_space(occdf, "genus", lng = "lng")
+      tax_range_space(data, "genus", lng = "lng")
     Condition
       Error in `tax_range_space()`:
-      ! All arguments must be named (except for "occdf").
+      ! All arguments must be named (except for "data").
       i Currently, there is 1 argument that should be named.
 
 # argument 'name' works
 
     Code
-      tax_range_space(occdf = occdf, name = "nonexistent")
+      tax_range_space(data = data, name = "nonexistent")
     Condition
       Error in `tax_range_space()`:
-      ! Column "nonexistent" not found in `occdf`.
+      ! Column "nonexistent" not found in `data`.
 
 ---
 
     Code
-      tax_range_space(occdf = nadf, name = "genus")
+      tax_range_space(data = nadf, name = "genus")
     Condition
       Error in `tax_range_space()`:
-      ! Column "genus" in `occdf` must not have missing values.
+      ! Column "genus" in `data` must not have missing values.
 
 # argument 'lng' works
 
     Code
-      tax_range_space(occdf, lng = "nonexistent")
+      tax_range_space(data, lng = "nonexistent")
     Condition
       Error in `tax_range_space()`:
-      ! Column "nonexistent" not found in `occdf`.
+      ! Column "nonexistent" not found in `data`.
 
 ---
 
@@ -79,7 +79,7 @@
       tax_range_space(chardf)
     Condition
       Error in `tax_range_space()`:
-      ! Column "lng" in `occdf` must be <numeric>, not <character>.
+      ! Column "lng" in `data` must be <numeric>, not <character>.
 
 ---
 
@@ -87,15 +87,15 @@
       tax_range_space(nadf)
     Condition
       Error in `tax_range_space()`:
-      ! Column "lng" in `occdf` must not have missing values.
+      ! Column "lng" in `data` must not have missing values.
 
 # argument 'lat' works
 
     Code
-      tax_range_space(occdf, lat = "nonexistent")
+      tax_range_space(data, lat = "nonexistent")
     Condition
       Error in `tax_range_space()`:
-      ! Column "nonexistent" not found in `occdf`.
+      ! Column "nonexistent" not found in `data`.
 
 ---
 
@@ -103,7 +103,7 @@
       tax_range_space(chardf)
     Condition
       Error in `tax_range_space()`:
-      ! Column "lat" in `occdf` must be <numeric>, not <character>.
+      ! Column "lat" in `data` must be <numeric>, not <character>.
 
 ---
 
@@ -111,12 +111,12 @@
       tax_range_space(nadf)
     Condition
       Error in `tax_range_space()`:
-      ! Column "lat" in `occdf` must not have missing values.
+      ! Column "lat" in `data` must not have missing values.
 
 # argument 'method' works
 
     Code
-      tax_range_space(occdf, method = c("gcd", "occ"))
+      tax_range_space(data, method = c("gcd", "occ"))
     Condition
       Error in `tax_range_space()`:
       ! `method` must be a single string, not a character vector.
@@ -124,7 +124,7 @@
 ---
 
     Code
-      tax_range_space(occdf, method = "test")
+      tax_range_space(data, method = "test")
     Condition
       Error in `tax_range_space()`:
       ! `method` must be one of "lat", "con", "gcd", or "occ", not "test".
@@ -132,7 +132,7 @@
 ---
 
     Code
-      tax_range_space(occdf, method = character(0))
+      tax_range_space(data, method = character(0))
     Condition
       Error in `tax_range_space()`:
       ! `method` must be a single string, not an empty character vector.
@@ -140,7 +140,7 @@
 ---
 
     Code
-      tax_range_space(occdf, method = NA)
+      tax_range_space(data, method = NA)
     Condition
       Error in `tax_range_space()`:
       ! `method` must be a single string, not `NA`.
@@ -148,7 +148,7 @@
 ---
 
     Code
-      tax_range_space(occdf, method = 1)
+      tax_range_space(data, method = 1)
     Condition
       Error in `tax_range_space()`:
       ! `method` must be a single string, not the number 1.
@@ -156,7 +156,7 @@
 # argument 'spacing' works
 
     Code
-      tax_range_space(occdf, method = "occ", spacing = "a")
+      tax_range_space(data, method = "occ", spacing = "a")
     Condition
       Error in `tax_range_space()`:
       ! `spacing` must be a number, not the string "a".
@@ -164,7 +164,7 @@
 ---
 
     Code
-      tax_range_space(occdf, method = "occ", spacing = numeric(0))
+      tax_range_space(data, method = "occ", spacing = numeric(0))
     Condition
       Error in `tax_range_space()`:
       ! `spacing` must be a number, not an empty numeric vector.
@@ -172,7 +172,7 @@
 ---
 
     Code
-      tax_range_space(occdf, method = "occ", spacing = NA)
+      tax_range_space(data, method = "occ", spacing = NA)
     Condition
       Error in `tax_range_space()`:
       ! `spacing` must be a number, not `NA`.
@@ -180,7 +180,7 @@
 ---
 
     Code
-      tax_range_space(occdf, method = "occ", spacing = 1:2)
+      tax_range_space(data, method = "occ", spacing = 1:2)
     Condition
       Error in `tax_range_space()`:
       ! `spacing` must be a number, not an integer vector.
@@ -188,7 +188,7 @@
 # argument 'coords' works
 
     Code
-      tax_range_space(occdf, method = "gcd", coords = "a")
+      tax_range_space(data, method = "gcd", coords = "a")
     Condition
       Error in `tax_range_space()`:
       ! `coords` must be `TRUE` or `FALSE`, not the string "a".
@@ -196,7 +196,7 @@
 ---
 
     Code
-      tax_range_space(occdf, method = "gcd", coords = logical(0))
+      tax_range_space(data, method = "gcd", coords = logical(0))
     Condition
       Error in `tax_range_space()`:
       ! `coords` must be `TRUE` or `FALSE`, not an empty logical vector.
@@ -204,7 +204,7 @@
 ---
 
     Code
-      tax_range_space(occdf, method = "gcd", coords = NA)
+      tax_range_space(data, method = "gcd", coords = NA)
     Condition
       Error in `tax_range_space()`:
       ! `coords` must be `TRUE` or `FALSE`, not `NA`.

--- a/tests/testthat/_snaps/tax_range_strat.md
+++ b/tests/testthat/_snaps/tax_range_strat.md
@@ -4,7 +4,7 @@
       tax_range_strat(data.frame())
     Condition
       Error in `tax_range_strat()`:
-      ! Column "genus" not found in `occdf`.
+      ! Column "genus" not found in `data`.
 
 ---
 
@@ -12,7 +12,7 @@
       tax_range_strat(NULL)
     Condition
       Error in `tax_range_strat()`:
-      ! `occdf` must be of class <data.frame>, not `NULL`.
+      ! `data` must be of class <data.frame>, not `NULL`.
 
 ---
 
@@ -20,7 +20,7 @@
       tax_range_strat(NA)
     Condition
       Error in `tax_range_strat()`:
-      ! `occdf` must be of class <data.frame>, not `NA`.
+      ! `data` must be of class <data.frame>, not `NA`.
 
 ---
 
@@ -28,56 +28,56 @@
       tax_range_strat("a")
     Condition
       Error in `tax_range_strat()`:
-      ! `occdf` must be of class <data.frame>, not the string "a".
+      ! `data` must be of class <data.frame>, not the string "a".
 
 # tax_range_strat errors with unnamed args
 
     Code
-      tax_range_strat(occdf, "genus")
+      tax_range_strat(data, "genus")
     Condition
       Error in `tax_range_strat()`:
-      ! All arguments must be named (except for "occdf").
+      ! All arguments must be named (except for "data").
       i Currently, there is 1 argument that should be named.
 
 ---
 
     Code
-      tax_range_strat(occdf, "genus")
+      tax_range_strat(data, "genus")
     Condition
       Error in `tax_range_strat()`:
-      ! All arguments must be named (except for "occdf").
+      ! All arguments must be named (except for "data").
       i Currently, there is 1 argument that should be named.
 
 ---
 
     Code
-      tax_range_strat(occdf, "genus", "bed")
+      tax_range_strat(data, "genus", "bed")
     Condition
       Error in `tax_range_strat()`:
-      ! All arguments must be named (except for "occdf").
+      ! All arguments must be named (except for "data").
       i Currently, there are 2 arguments that should be named.
 
 ---
 
     Code
-      tax_range_strat(occdf, "genus", level = "bed")
+      tax_range_strat(data, "genus", level = "bed")
     Condition
       Error in `tax_range_strat()`:
-      ! All arguments must be named (except for "occdf").
+      ! All arguments must be named (except for "data").
       i Currently, there is 1 argument that should be named.
 
 # argument 'name' works
 
     Code
-      tax_range_strat(occdf, name = "test")
+      tax_range_strat(data, name = "test")
     Condition
       Error in `tax_range_strat()`:
-      ! Column "test" not found in `occdf`.
+      ! Column "test" not found in `data`.
 
 ---
 
     Code
-      tax_range_strat(occdf, name = character(0))
+      tax_range_strat(data, name = character(0))
     Condition
       Error in `tax_range_strat()`:
       ! `name` must be a single string, not an empty character vector.
@@ -85,7 +85,7 @@
 ---
 
     Code
-      tax_range_strat(occdf, name = NA)
+      tax_range_strat(data, name = NA)
     Condition
       Error in `tax_range_strat()`:
       ! `name` must be a single string, not `NA`.
@@ -93,7 +93,7 @@
 ---
 
     Code
-      tax_range_strat(occdf, name = 1)
+      tax_range_strat(data, name = 1)
     Condition
       Error in `tax_range_strat()`:
       ! `name` must be a single string, not the number 1.
@@ -104,20 +104,20 @@
       tax_range_strat(nadf)
     Condition
       Error in `tax_range_strat()`:
-      ! Column "genus" in `occdf` must not have missing values.
+      ! Column "genus" in `data` must not have missing values.
 
 # argument 'level' works
 
     Code
-      tax_range_strat(occdf, level = "test")
+      tax_range_strat(data, level = "test")
     Condition
       Error in `tax_range_strat()`:
-      ! Column "test" not found in `occdf`.
+      ! Column "test" not found in `data`.
 
 ---
 
     Code
-      tax_range_strat(occdf, level = character(0))
+      tax_range_strat(data, level = character(0))
     Condition
       Error in `tax_range_strat()`:
       ! `level` must be a single string, not an empty character vector.
@@ -125,7 +125,7 @@
 ---
 
     Code
-      tax_range_strat(occdf, level = NA)
+      tax_range_strat(data, level = NA)
     Condition
       Error in `tax_range_strat()`:
       ! `level` must be a single string, not `NA`.
@@ -133,7 +133,7 @@
 ---
 
     Code
-      tax_range_strat(occdf, level = 1)
+      tax_range_strat(data, level = 1)
     Condition
       Error in `tax_range_strat()`:
       ! `level` must be a single string, not the number 1.
@@ -144,12 +144,12 @@
       tax_range_strat(nadf)
     Condition
       Error in `tax_range_strat()`:
-      ! Column "bed" in `occdf` must be of class <numeric>, not <logical>.
+      ! Column "bed" in `data` must be of class <numeric>, not <logical>.
 
 # argument 'group' works
 
     Code
-      tax_range_strat(occdf, group = c("class", "genus"))
+      tax_range_strat(data, group = c("class", "genus"))
     Condition
       Error in `tax_range_strat()`:
       ! `group` must be a single string, not a character vector.
@@ -157,15 +157,15 @@
 ---
 
     Code
-      tax_range_strat(occdf, group = "test")
+      tax_range_strat(data, group = "test")
     Condition
       Error in `tax_range_strat()`:
-      ! Column "test" not found in `occdf`.
+      ! Column "test" not found in `data`.
 
 ---
 
     Code
-      tax_range_strat(occdf, group = character(0))
+      tax_range_strat(data, group = character(0))
     Condition
       Error in `tax_range_strat()`:
       ! `group` must be a single string, not an empty character vector.
@@ -173,7 +173,7 @@
 ---
 
     Code
-      tax_range_strat(occdf, group = NA)
+      tax_range_strat(data, group = NA)
     Condition
       Error in `tax_range_strat()`:
       ! `group` must be a single string, not `NA`.
@@ -181,7 +181,7 @@
 ---
 
     Code
-      tax_range_strat(occdf, group = 1)
+      tax_range_strat(data, group = 1)
     Condition
       Error in `tax_range_strat()`:
       ! `group` must be a single string, not the number 1.
@@ -189,7 +189,7 @@
 # argument 'certainty' works
 
     Code
-      tax_range_strat(occdf, certainty = c("class", "genus"))
+      tax_range_strat(data, certainty = c("class", "genus"))
     Condition
       Error in `tax_range_strat()`:
       ! `certainty` must be a single string, not a character vector.
@@ -197,15 +197,15 @@
 ---
 
     Code
-      tax_range_strat(occdf, certainty = "test")
+      tax_range_strat(data, certainty = "test")
     Condition
       Error in `tax_range_strat()`:
-      ! Column "test" not found in `occdf`.
+      ! Column "test" not found in `data`.
 
 ---
 
     Code
-      tax_range_strat(occdf, certainty = character(0))
+      tax_range_strat(data, certainty = character(0))
     Condition
       Error in `tax_range_strat()`:
       ! `certainty` must be a single string, not an empty character vector.
@@ -213,7 +213,7 @@
 ---
 
     Code
-      tax_range_strat(occdf, certainty = NA)
+      tax_range_strat(data, certainty = NA)
     Condition
       Error in `tax_range_strat()`:
       ! `certainty` must be a single string, not `NA`.
@@ -221,7 +221,7 @@
 ---
 
     Code
-      tax_range_strat(occdf, certainty = 1)
+      tax_range_strat(data, certainty = 1)
     Condition
       Error in `tax_range_strat()`:
       ! `certainty` must be a single string, not the number 1.
@@ -229,7 +229,7 @@
 # argument 'by' works
 
     Code
-      tax_range_strat(occdf, by = c("FAD", "LAD"))
+      tax_range_strat(data, by = c("FAD", "LAD"))
     Condition
       Error in `tax_range_strat()`:
       ! `by` must be a single string, not a character vector.
@@ -237,7 +237,7 @@
 ---
 
     Code
-      tax_range_strat(occdf, by = "test")
+      tax_range_strat(data, by = "test")
     Condition
       Error in `tax_range_strat()`:
       ! `by` must be one of "FAD", "LAD", or "name", not "test".
@@ -245,7 +245,7 @@
 ---
 
     Code
-      tax_range_strat(occdf, by = character(0))
+      tax_range_strat(data, by = character(0))
     Condition
       Error in `tax_range_strat()`:
       ! `by` must be a single string, not an empty character vector.
@@ -253,7 +253,7 @@
 ---
 
     Code
-      tax_range_strat(occdf, by = NA)
+      tax_range_strat(data, by = NA)
     Condition
       Error in `tax_range_strat()`:
       ! `by` must be a single string, not `NA`.
@@ -261,7 +261,7 @@
 ---
 
     Code
-      tax_range_strat(occdf, by = 1)
+      tax_range_strat(data, by = 1)
     Condition
       Error in `tax_range_strat()`:
       ! `by` must be a single string, not the number 1.

--- a/tests/testthat/_snaps/tax_range_time.md
+++ b/tests/testthat/_snaps/tax_range_time.md
@@ -1,60 +1,60 @@
 # basic behaviour works
 
     Code
-      tax_range_time(occdf = data.frame())
+      tax_range_time(data = data.frame())
     Condition
       Error in `tax_range_time()`:
-      ! Column "genus" not found in `occdf`.
+      ! Column "genus" not found in `data`.
 
 ---
 
     Code
-      tax_range_time(occdf = NULL)
+      tax_range_time(data = NULL)
     Condition
       Error in `tax_range_time()`:
-      ! `occdf` must be of class <data.frame>, not `NULL`.
+      ! `data` must be of class <data.frame>, not `NULL`.
 
 ---
 
     Code
-      tax_range_time(occdf = NA)
+      tax_range_time(data = NA)
     Condition
       Error in `tax_range_time()`:
-      ! `occdf` must be of class <data.frame>, not `NA`.
+      ! `data` must be of class <data.frame>, not `NA`.
 
 ---
 
     Code
-      tax_range_time(occdf = "a")
+      tax_range_time(data = "a")
     Condition
       Error in `tax_range_time()`:
-      ! `occdf` must be of class <data.frame>, not the string "a".
+      ! `data` must be of class <data.frame>, not the string "a".
 
 # tax_range_time errors with unnamed args
 
     Code
-      tax_range_time(occdf, "genus")
+      tax_range_time(data, "genus")
     Condition
       Error in `tax_range_time()`:
-      ! All arguments must be named (except for "occdf").
+      ! All arguments must be named (except for "data").
       i Currently, there is 1 argument that should be named.
 
 ---
 
     Code
-      tax_range_time(occdf, "genus", "min_ma")
+      tax_range_time(data, "genus", "min_ma")
     Condition
       Error in `tax_range_time()`:
-      ! All arguments must be named (except for "occdf").
+      ! All arguments must be named (except for "data").
       i Currently, there are 2 arguments that should be named.
 
 ---
 
     Code
-      tax_range_time(occdf, "genus", min_ma = "min_ma")
+      tax_range_time(data, "genus", min_ma = "min_ma")
     Condition
       Error in `tax_range_time()`:
-      ! All arguments must be named (except for "occdf").
+      ! All arguments must be named (except for "data").
       i Currently, there is 1 argument that should be named.
 
 # argument 'name' works
@@ -63,12 +63,12 @@
       tax_range_time(nadf, name = "species")
     Condition
       Error in `tax_range_time()`:
-      ! Column "species" in `occdf` must not have missing values.
+      ! Column "species" in `data` must not have missing values.
 
 ---
 
     Code
-      tax_range_time(occdf, name = c("Species", "max_ma"))
+      tax_range_time(data, name = c("Species", "max_ma"))
     Condition
       Error in `tax_range_time()`:
       ! `name` must be a single string, not a character vector.
@@ -76,15 +76,15 @@
 ---
 
     Code
-      tax_range_time(occdf, name = "nonexistent")
+      tax_range_time(data, name = "nonexistent")
     Condition
       Error in `tax_range_time()`:
-      ! Column "nonexistent" not found in `occdf`.
+      ! Column "nonexistent" not found in `data`.
 
 ---
 
     Code
-      tax_range_time(occdf, name = 1)
+      tax_range_time(data, name = 1)
     Condition
       Error in `tax_range_time()`:
       ! `name` must be a single string, not the number 1.
@@ -92,7 +92,7 @@
 ---
 
     Code
-      tax_range_time(occdf, name = NA)
+      tax_range_time(data, name = NA)
     Condition
       Error in `tax_range_time()`:
       ! `name` must be a single string, not `NA`.
@@ -100,7 +100,7 @@
 ---
 
     Code
-      tax_range_time(occdf, name = NULL)
+      tax_range_time(data, name = NULL)
     Condition
       Error in `tax_range_time()`:
       ! `name` must be a single string, not `NULL`.
@@ -108,7 +108,7 @@
 # argument 'max_ma' works
 
     Code
-      tax_range_time(occdf, max_ma = c("Species", "max_ma"))
+      tax_range_time(data, max_ma = c("Species", "max_ma"))
     Condition
       Error in `tax_range_time()`:
       ! `max_ma` must be a single string, not a character vector.
@@ -116,15 +116,15 @@
 ---
 
     Code
-      tax_range_time(occdf, max_ma = "nonexistent")
+      tax_range_time(data, max_ma = "nonexistent")
     Condition
       Error in `tax_range_time()`:
-      ! Column "nonexistent" not found in `occdf`.
+      ! Column "nonexistent" not found in `data`.
 
 ---
 
     Code
-      tax_range_time(occdf, max_ma = 1)
+      tax_range_time(data, max_ma = 1)
     Condition
       Error in `tax_range_time()`:
       ! `max_ma` must be a single string, not the number 1.
@@ -132,7 +132,7 @@
 ---
 
     Code
-      tax_range_time(occdf, max_ma = NA)
+      tax_range_time(data, max_ma = NA)
     Condition
       Error in `tax_range_time()`:
       ! `max_ma` must be a single string, not `NA`.
@@ -140,7 +140,7 @@
 ---
 
     Code
-      tax_range_time(occdf, max_ma = NULL)
+      tax_range_time(data, max_ma = NULL)
     Condition
       Error in `tax_range_time()`:
       ! `max_ma` must be a single string, not `NULL`.
@@ -151,7 +151,7 @@
       tax_range_time(chardf)
     Condition
       Error in `tax_range_time()`:
-      ! Column "max_ma" in `occdf` must be of class <numeric>, not <character>.
+      ! Column "max_ma" in `data` must be of class <numeric>, not <character>.
 
 ---
 
@@ -159,12 +159,12 @@
       tax_range_time(nadf)
     Condition
       Error in `tax_range_time()`:
-      ! Column "max_ma" in `occdf` must not have missing values.
+      ! Column "max_ma" in `data` must not have missing values.
 
 # argument 'min_ma' works
 
     Code
-      tax_range_time(occdf, min_ma = c("Species", "min_ma"))
+      tax_range_time(data, min_ma = c("Species", "min_ma"))
     Condition
       Error in `tax_range_time()`:
       ! `min_ma` must be a single string, not a character vector.
@@ -172,15 +172,15 @@
 ---
 
     Code
-      tax_range_time(occdf, min_ma = "nonexistent")
+      tax_range_time(data, min_ma = "nonexistent")
     Condition
       Error in `tax_range_time()`:
-      ! Column "nonexistent" not found in `occdf`.
+      ! Column "nonexistent" not found in `data`.
 
 ---
 
     Code
-      tax_range_time(occdf, min_ma = 1)
+      tax_range_time(data, min_ma = 1)
     Condition
       Error in `tax_range_time()`:
       ! `min_ma` must be a single string, not the number 1.
@@ -188,7 +188,7 @@
 ---
 
     Code
-      tax_range_time(occdf, min_ma = NA)
+      tax_range_time(data, min_ma = NA)
     Condition
       Error in `tax_range_time()`:
       ! `min_ma` must be a single string, not `NA`.
@@ -196,7 +196,7 @@
 ---
 
     Code
-      tax_range_time(occdf, min_ma = NULL)
+      tax_range_time(data, min_ma = NULL)
     Condition
       Error in `tax_range_time()`:
       ! `min_ma` must be a single string, not `NULL`.
@@ -207,7 +207,7 @@
       tax_range_time(chardf)
     Condition
       Error in `tax_range_time()`:
-      ! Column "min_ma" in `occdf` must be of class <numeric>, not <character>.
+      ! Column "min_ma" in `data` must be of class <numeric>, not <character>.
 
 ---
 
@@ -215,21 +215,21 @@
       tax_range_time(nadf)
     Condition
       Error in `tax_range_time()`:
-      ! Column "min_ma" in `occdf` must not have missing values.
+      ! Column "min_ma" in `data` must not have missing values.
 
 # max ages must be larger than or equal to min ages
 
     Code
-      tax_range_time(occdf)
+      tax_range_time(data)
     Condition
       Error in `tax_range_time()`:
       ! Maximum age must be larger than or equal to minimum age.
-      i Row(s) of `occdf` where "max_ma" is smaller than "min_ma": 2, 3.
+      i Row(s) of `data` where "max_ma" is smaller than "min_ma": 2, 3.
 
 # argument 'group' works
 
     Code
-      tax_range_time(occdf, group = c("genus", "min_ma"))
+      tax_range_time(data, group = c("genus", "min_ma"))
     Condition
       Error in `tax_range_time()`:
       ! `group` must be a single string, not a character vector.
@@ -237,15 +237,15 @@
 ---
 
     Code
-      tax_range_time(occdf, group = "nonexistent")
+      tax_range_time(data, group = "nonexistent")
     Condition
       Error in `tax_range_time()`:
-      ! Column "nonexistent" not found in `occdf`.
+      ! Column "nonexistent" not found in `data`.
 
 ---
 
     Code
-      tax_range_time(occdf, group = 1)
+      tax_range_time(data, group = 1)
     Condition
       Error in `tax_range_time()`:
       ! `group` must be a single string, not the number 1.
@@ -253,7 +253,7 @@
 ---
 
     Code
-      tax_range_time(occdf, group = NA)
+      tax_range_time(data, group = NA)
     Condition
       Error in `tax_range_time()`:
       ! `group` must be a single string, not `NA`.
@@ -261,7 +261,7 @@
 # argument 'by' works
 
     Code
-      tax_range_time(occdf, by = c("genus", "min_ma"))
+      tax_range_time(data, by = c("genus", "min_ma"))
     Condition
       Error in `tax_range_time()`:
       ! `by` must be a single string, not a character vector.
@@ -269,7 +269,7 @@
 ---
 
     Code
-      tax_range_time(occdf, by = "nonexistent")
+      tax_range_time(data, by = "nonexistent")
     Condition
       Error in `tax_range_time()`:
       ! `by` must be one of "FAD", "LAD", or "name", not "nonexistent".
@@ -277,7 +277,7 @@
 ---
 
     Code
-      tax_range_time(occdf, by = 1)
+      tax_range_time(data, by = 1)
     Condition
       Error in `tax_range_time()`:
       ! `by` must be a single string, not the number 1.
@@ -285,7 +285,7 @@
 ---
 
     Code
-      tax_range_time(occdf, by = NA)
+      tax_range_time(data, by = NA)
     Condition
       Error in `tax_range_time()`:
       ! `by` must be a single string, not `NA`.
@@ -293,7 +293,7 @@
 # argument 'plot' works
 
     Code
-      tax_range_time(occdf, plot = "test")
+      tax_range_time(data, plot = "test")
     Condition
       Error in `tax_range_time()`:
       ! `plot` must be `TRUE` or `FALSE`, not the string "test".
@@ -301,7 +301,7 @@
 ---
 
     Code
-      tax_range_time(occdf, plot = NA)
+      tax_range_time(data, plot = NA)
     Condition
       Error in `tax_range_time()`:
       ! `plot` must be `TRUE` or `FALSE`, not `NA`.
@@ -309,7 +309,7 @@
 # argument 'plot_args' works
 
     Code
-      tax_range_time(occdf, plot_args = "test")
+      tax_range_time(data, plot_args = "test")
     Condition
       Error in `tax_range_time()`:
       ! `plot_args` must be of class <list> or `NULL`, not the string "test".
@@ -317,7 +317,7 @@
 ---
 
     Code
-      tax_range_time(occdf, plot_args = NA)
+      tax_range_time(data, plot_args = NA)
     Condition
       Error in `tax_range_time()`:
       ! `plot_args` must be of class <list> or `NULL`, not `NA`.

--- a/tests/testthat/_snaps/tax_unique.md
+++ b/tests/testthat/_snaps/tax_unique.md
@@ -6,7 +6,7 @@
       species = "species", genus = "genus")
     Condition
       Error in `tax_unique()`:
-      ! Column "species" not found in `occdf`.
+      ! Column "species" not found in `data`.
 
 ---
 
@@ -16,7 +16,7 @@
       species = "species", genus = "genus")
     Condition
       Error in `tax_unique()`:
-      ! Column "genus" not found in `occdf`.
+      ! Column "genus" not found in `data`.
 
 ---
 
@@ -32,7 +32,7 @@
       tax_unique(100)
     Condition
       Error in `tax_unique()`:
-      ! `occdf` must be of class <data.frame>, not the number 100.
+      ! `data` must be of class <data.frame>, not the number 100.
 
 ---
 
@@ -40,7 +40,7 @@
       tax_unique(NA)
     Condition
       Error in `tax_unique()`:
-      ! `occdf` must be of class <data.frame>, not `NA`.
+      ! `data` must be of class <data.frame>, not `NA`.
 
 ---
 
@@ -48,7 +48,7 @@
       tax_unique()
     Condition
       Error in `tax_unique()`:
-      ! `occdf` must be of class <data.frame>, not absent.
+      ! `data` must be of class <data.frame>, not absent.
 
 # tax_unique errors with unnamed args
 
@@ -56,7 +56,7 @@
       tax_unique(dinosaurs, "genus")
     Condition
       Error in `tax_unique()`:
-      ! All arguments must be named (except for "occdf").
+      ! All arguments must be named (except for "data").
       i Currently, there is 1 argument that should be named.
 
 ---
@@ -65,7 +65,7 @@
       tax_unique(dinosaurs, "genus", "species")
     Condition
       Error in `tax_unique()`:
-      ! All arguments must be named (except for "occdf").
+      ! All arguments must be named (except for "data").
       i Currently, there are 2 arguments that should be named.
 
 ---
@@ -74,7 +74,7 @@
       tax_unique(dinosaurs, "genus", order = "species")
     Condition
       Error in `tax_unique()`:
-      ! All arguments must be named (except for "occdf").
+      ! All arguments must be named (except for "data").
       i Currently, there is 1 argument that should be named.
 
 # tax_unique() cannot use the same column for multiple arguments
@@ -100,7 +100,7 @@
       tax_unique(dinosaurs, binomial = "test")
     Condition
       Error in `tax_unique()`:
-      ! Column "test" not found in `occdf`.
+      ! Column "test" not found in `data`.
 
 ---
 
@@ -132,7 +132,7 @@
       tax_unique(dinosaurs, genus = "genus", family = "family", name = "test")
     Condition
       Error in `tax_unique()`:
-      ! Column "test" not found in `occdf`.
+      ! Column "test" not found in `data`.
 
 ---
 
@@ -153,7 +153,7 @@
 # higher taxonomic levels supplied via `...` work
 
     Code
-      tax_unique(occdf = dinosaurs, species = "species", genus = "genus")
+      tax_unique(data = dinosaurs, species = "species", genus = "genus")
     Condition
       Error in `tax_unique()`:
       ! At least one higher taxonomic level must be supplied (e.g. `family = "family"`).
@@ -164,7 +164,7 @@
       tax_unique(dinosaurs, species = "species", genus = "genus", family = "test")
     Condition
       Error in `tax_unique()`:
-      ! Column "test" not found in `occdf`.
+      ! Column "test" not found in `data`.
 
 ---
 
@@ -186,7 +186,7 @@
 # arg 'resolution' works
 
     Code
-      tax_unique(occdf = dinosaurs, species = "species", genus = "genus", family = "family",
+      tax_unique(data = dinosaurs, species = "species", genus = "genus", family = "family",
         resolution = "test")
     Condition
       Error in `tax_unique()`:
@@ -195,7 +195,7 @@
 ---
 
     Code
-      tax_unique(occdf = dinosaurs, species = "species", genus = "genus", family = "family",
+      tax_unique(data = dinosaurs, species = "species", genus = "genus", family = "family",
         resolution = 1)
     Condition
       Error in `tax_unique()`:
@@ -204,7 +204,7 @@
 ---
 
     Code
-      tax_unique(occdf = dinosaurs, species = "species", genus = "genus", family = "family",
+      tax_unique(data = dinosaurs, species = "species", genus = "genus", family = "family",
         resolution = character(0))
     Condition
       Error in `tax_unique()`:
@@ -231,7 +231,7 @@
 # taxonomic columns must not contain punctuation
 
     Code
-      tax_unique(occdf = tetrapods, genus = "identified_name", family = "family",
+      tax_unique(data = tetrapods, genus = "identified_name", family = "family",
         resolution = "genus")
     Condition
       Error in `tax_unique()`:
@@ -240,7 +240,7 @@
 ---
 
     Code
-      tax_unique(occdf = tetrapods, genus = "genus", family = "identified_name",
+      tax_unique(data = tetrapods, genus = "genus", family = "identified_name",
         resolution = "genus")
     Condition
       Error in `tax_unique()`:
@@ -249,7 +249,7 @@
 ---
 
     Code
-      tax_unique(occdf = tetrapods, species = "identified_name", genus = "genus",
+      tax_unique(data = tetrapods, species = "identified_name", genus = "genus",
         family = "family", resolution = "genus")
     Condition
       Error in `tax_unique()`:

--- a/tests/testthat/setup-data.R
+++ b/tests/testthat/setup-data.R
@@ -3,7 +3,7 @@ periods <- subset(GTS2020, rank == "period")
 epochs <- subset(GTS2020, rank == "epoch")
 
 reef_df <- look_up(
-  occdf = reefs,
+  data = reefs,
   early_interval = "interval",
   late_interval = "interval",
   int_key = interval_key

--- a/tests/testthat/test-bin_lat.R
+++ b/tests/testthat/test-bin_lat.R
@@ -5,7 +5,7 @@ test_that("bin_lat works", {
   # We don't lose or gain observations
   expect_warning(
     expect_equal(
-      nrow(bin_lat(occdf = tetrapods, bins = bins, lat = "lat")),
+      nrow(bin_lat(data = tetrapods, bins = bins, lat = "lat")),
       nrow(tetrapods)
     ),
     "Occurrences assigned to upper bin"
@@ -16,7 +16,7 @@ test_that("bin_lat works", {
     tetrapods[, "lat", drop = TRUE] %in% c(bins$max, bins$min)
   ))
   expect_equal(
-    nrow(bin_lat(occdf = tetrapods, bins = bins, lat = "lat", boundary = TRUE)),
+    nrow(bin_lat(data = tetrapods, bins = bins, lat = "lat", boundary = TRUE)),
     nrow(tetrapods) + bo
   )
 })
@@ -24,27 +24,27 @@ test_that("bin_lat works", {
 test_that("bin_lat errors with unnamed args", {
   bins <- lat_bins_degrees(size = 10)
   expect_snapshot(bin_lat(tetrapods, bins), error = TRUE)
-  expect_snapshot(bin_lat(occdf = tetrapods, bins), error = TRUE)
+  expect_snapshot(bin_lat(data = tetrapods, bins), error = TRUE)
   expect_snapshot(bin_lat(tetrapods, bins, "lat"), error = TRUE)
   expect_snapshot(bin_lat(tetrapods, bins, lat = "lat"), error = TRUE)
 })
 
 test_that("bin_lat error handling", {
   # We modify this data so copy it first
-  occdf <- tetrapods
+  data <- tetrapods
   # Generate latitudinal bins
   bins <- lat_bins_degrees(size = 10)
 
-  # occdf and bins should be dataframes
-  expect_snapshot(bin_lat(occdf = 2, bins = bins, lat = "lat"), error = TRUE)
+  # data and bins should be dataframes
+  expect_snapshot(bin_lat(data = 2, bins = bins, lat = "lat"), error = TRUE)
   expect_snapshot(
-    bin_lat(occdf = occdf, bins = 2, lat = "lat"),
+    bin_lat(data = data, bins = 2, lat = "lat"),
     error = TRUE
   )
 
   # column "lat" must exist in the data
   expect_snapshot(
-    bin_lat(occdf = occdf, bins = bins, lat = "plat"),
+    bin_lat(data = data, bins = bins, lat = "plat"),
     error = TRUE
   )
 
@@ -53,22 +53,22 @@ test_that("bin_lat error handling", {
     bins2 <- bins
     bins2[[i]] <- NULL
     expect_snapshot(
-      bin_lat(occdf = occdf, bins = bins2, lat = "lat"),
+      bin_lat(data = data, bins = bins2, lat = "lat"),
       error = TRUE
     )
   }
 
   # lat cannot have missing values
-  occdf$lat[1] <- NA
+  data$lat[1] <- NA
   expect_snapshot(
-    bin_lat(occdf = occdf, bins = bins, lat = "lat"),
+    bin_lat(data = data, bins = bins, lat = "lat"),
     error = TRUE
   )
 
   # lat must be between -90 and 90
-  occdf$lat[1] <- 91
+  data$lat[1] <- 91
   expect_snapshot(
-    bin_lat(occdf = occdf, bins = bins, lat = "lat"),
+    bin_lat(data = data, bins = bins, lat = "lat"),
     error = TRUE
   )
 })

--- a/tests/testthat/test-bin_space.R
+++ b/tests/testthat/test-bin_space.R
@@ -1,21 +1,21 @@
 test_that("bin_space() works", {
   # Reduce data size for faster testing
-  occdf <- head(tetrapods, n = 100)
+  data <- head(tetrapods, n = 100)
 
   # We don't lose or gain observations
   expect_message(
     expect_equal(
-      nrow(bin_space(occdf = occdf, spacing = 250, plot = TRUE)),
-      nrow(occdf)
+      nrow(bin_space(data = data, spacing = 250, plot = TRUE)),
+      nrow(data)
     ),
     "H3 resolution: 2"
   )
   expect_message(
     expect_equal(
       nrow(
-        bin_space(occdf = occdf, spacing = 1000, sub_grid = 250, plot = TRUE)
+        bin_space(data = data, spacing = 1000, sub_grid = 250, plot = TRUE)
       ),
-      nrow(occdf)
+      nrow(data)
     ),
     "H3 resolution: 1"
   )
@@ -23,7 +23,7 @@ test_that("bin_space() works", {
   # Check output type
   expect_message(
     expect_type(
-      bin_space(occdf = occdf, spacing = 250, return = TRUE, plot = TRUE),
+      bin_space(data = data, spacing = 250, return = TRUE, plot = TRUE),
       "list"
     ),
     "H3 resolution: 2"
@@ -31,7 +31,7 @@ test_that("bin_space() works", {
   expect_message(
     expect_type(
       bin_space(
-        occdf = occdf,
+        data = data,
         spacing = 500,
         sub_grid = 200,
         return = TRUE,
@@ -44,59 +44,59 @@ test_that("bin_space() works", {
 })
 
 test_that("piping and not piping the first argument give the same result", {
-  occdf <- head(tetrapods, n = 100)
+  data <- head(tetrapods, n = 100)
 
   expect_equal(
-    suppressMessages(occdf |> bin_space(spacing = 250)),
-    suppressMessages(bin_space(occdf, spacing = 250))
+    suppressMessages(data |> bin_space(spacing = 250)),
+    suppressMessages(bin_space(data, spacing = 250))
   )
 })
 
 test_that("bin_space errors with unnamed args", {
-  occdf <- head(tetrapods, n = 100)
+  data <- head(tetrapods, n = 100)
 
-  expect_snapshot(bin_space(occdf, "lng"), error = TRUE)
-  expect_snapshot(bin_space(occdf = occdf, "lng"), error = TRUE)
-  expect_snapshot(bin_space(occdf, "lng", "lat"), error = TRUE)
-  expect_snapshot(bin_space(occdf, "lng", lat = "lat"), error = TRUE)
+  expect_snapshot(bin_space(data, "lng"), error = TRUE)
+  expect_snapshot(bin_space(data = data, "lng"), error = TRUE)
+  expect_snapshot(bin_space(data, "lng", "lat"), error = TRUE)
+  expect_snapshot(bin_space(data, "lng", lat = "lat"), error = TRUE)
 })
 
 test_that("bin_space error handling", {
   # We modify this data so copy it first
-  occdf <- tetrapods
+  data <- tetrapods
 
   # wrong input type
-  expect_snapshot(bin_space(occdf = matrix(tetrapods)), error = TRUE)
-  expect_snapshot(bin_space(occdf = tetrapods, spacing = NA), error = TRUE)
-  expect_snapshot(bin_space(occdf = tetrapods, spacing = 1:2), error = TRUE)
-  expect_snapshot(bin_space(occdf = tetrapods, sub_grid = 1:2), error = TRUE)
+  expect_snapshot(bin_space(data = matrix(tetrapods)), error = TRUE)
+  expect_snapshot(bin_space(data = tetrapods, spacing = NA), error = TRUE)
+  expect_snapshot(bin_space(data = tetrapods, spacing = 1:2), error = TRUE)
+  expect_snapshot(bin_space(data = tetrapods, sub_grid = 1:2), error = TRUE)
   expect_snapshot(
-    bin_space(occdf = tetrapods, spacing = 1000, sub_grid = NA),
+    bin_space(data = tetrapods, spacing = 1000, sub_grid = NA),
     error = TRUE
   )
-  expect_snapshot(bin_space(occdf = tetrapods, return = "TRUE"), error = TRUE)
+  expect_snapshot(bin_space(data = tetrapods, return = "TRUE"), error = TRUE)
 
   # wrong columns
   expect_snapshot(
-    bin_space(occdf = tetrapods, lng = "long", lat = "latit"),
+    bin_space(data = tetrapods, lng = "long", lat = "latit"),
     error = TRUE
   )
 
   # spacing and sub_grid give the same resolution
   expect_snapshot(
-    bin_space(occdf = tetrapods, spacing = 1000, sub_grid = 1000),
+    bin_space(data = tetrapods, spacing = 1000, sub_grid = 1000),
     error = TRUE
   )
   # lat must be a numeric value between -90 and 90
-  occdf$lat[1] <- 94
-  expect_snapshot(bin_space(occdf = occdf), error = TRUE)
-  occdf$lat[1] <- "94"
-  expect_snapshot(bin_space(occdf = occdf), error = TRUE)
+  data$lat[1] <- 94
+  expect_snapshot(bin_space(data = data), error = TRUE)
+  data$lat[1] <- "94"
+  expect_snapshot(bin_space(data = data), error = TRUE)
 
   # lng must be a numeric value between -180 and 180
-  occdf <- tetrapods
-  occdf$lng[1] <- 184
-  expect_snapshot(bin_space(occdf = occdf), error = TRUE)
-  occdf$lng[1] <- "184"
-  expect_snapshot(bin_space(occdf = occdf), error = TRUE)
+  data <- tetrapods
+  data$lng[1] <- 184
+  expect_snapshot(bin_space(data = data), error = TRUE)
+  data$lng[1] <- "184"
+  expect_snapshot(bin_space(data = data), error = TRUE)
 })

--- a/tests/testthat/test-bin_time.R
+++ b/tests/testthat/test-bin_time.R
@@ -7,7 +7,7 @@ test_bins <- data.frame(
   max_ma = c(10, 20, 30, 40, 50)
 )
 
-test_occdf <- rbind(
+test_data <- rbind(
   # Single-bin cases ------------------------------------
 
   # Falls entirely within bin 1: all methods should agree.
@@ -47,16 +47,16 @@ test_occdf <- rbind(
 ) |>
   as.data.frame()
 
-colnames(test_occdf) <- c("name", "min_ma", "max_ma")
-test_occdf$min_ma <- as.numeric(test_occdf$min_ma)
-test_occdf$max_ma <- as.numeric(test_occdf$max_ma)
+colnames(test_data) <- c("name", "min_ma", "max_ma")
+test_data$min_ma <- as.numeric(test_data$min_ma)
+test_data$max_ma <- as.numeric(test_data$max_ma)
 
 
 test_that("bin_time() works with method 'mid'", {
   # occ3's midpoint (10) equals a bin boundary, which triggers a warning and
   # returns an NA assignment
   expect_warning(
-    bin_mid <- bin_time(occdf = test_occdf, bins = test_bins, method = "mid"),
+    bin_mid <- bin_time(data = test_data, bins = test_bins, method = "mid"),
     "equivalent to a bin boundary"
   )
   expect_equal(
@@ -73,13 +73,13 @@ test_that("bin_time() works with method 'mid'", {
   )
   # TODO: regression test for https://github.com/palaeoverse/palaeoverse/issues/236
   # expect_silent(
-  #   bin_time(occdf = test_occdf[5, ], bins = test_bins, method = "mid")
+  #   bin_time(data = test_data[5, ], bins = test_bins, method = "mid")
   # )
 })
 
 test_that("bin_time() works with method 'majority'", {
   bin_majority <- bin_time(
-    occdf = test_occdf,
+    data = test_data,
     bins = test_bins,
     method = "majority"
   )
@@ -101,13 +101,13 @@ test_that("bin_time() works with method 'majority'", {
 
 test_that("piping and not piping the first argument give the same result", {
   expect_equal(
-    test_occdf |> bin_time(bins = test_bins, method = "majority"),
-    bin_time(test_occdf, bins = test_bins, method = "majority")
+    test_data |> bin_time(bins = test_bins, method = "majority"),
+    bin_time(test_data, bins = test_bins, method = "majority")
   )
 })
 
 test_that("bin_time() works with method 'all'", {
-  bin_all <- bin_time(occdf = test_occdf, bins = test_bins, method = "all")
+  bin_all <- bin_time(data = test_data, bins = test_bins, method = "all")
   # Occurrences spanning several bins are duplicated, one row per bin
   # fmt: skip
   expect_equal(
@@ -130,7 +130,7 @@ test_that("bin_time() works with method 'all'", {
 test_that("bin_time() works with method 'random'", {
   set.seed(1234)
   bin_random <- bin_time(
-    occdf = test_occdf,
+    data = test_data,
     bins = test_bins,
     method = "random",
     reps = 5
@@ -147,7 +147,7 @@ test_that("bin_time() works with method 'random'", {
       expect_s3_class(x, "data.frame")
       expect_named(
         x,
-        c(names(test_occdf), "id", "n_bins", "bin_assignment", "bin_midpoint")
+        c(names(test_data), "id", "n_bins", "bin_assignment", "bin_midpoint")
       )
 
       # Those observations are contained in a single interval so they shouldn't
@@ -193,7 +193,7 @@ test_that("bin_time() works with method 'random'", {
 test_that("bin_time() works with method 'point'", {
   set.seed(1234)
   bin_point <- bin_time(
-    occdf = test_occdf,
+    data = test_data,
     bins = test_bins,
     method = "point",
     reps = 5
@@ -211,7 +211,7 @@ test_that("bin_time() works with method 'point'", {
       expect_named(
         x,
         c(
-          names(test_occdf),
+          names(test_data),
           "id",
           "n_bins",
           "bin_assignment",
@@ -267,7 +267,7 @@ test_that("bin_time() works with method 'point'", {
 test_that("user can pass custom function to method 'point'", {
   set.seed(1234)
   bin_point <- bin_time(
-    occdf = test_occdf,
+    data = test_data,
     bins = test_bins,
     method = "point",
     reps = 5,
@@ -288,7 +288,7 @@ test_that("user can pass custom function to method 'point'", {
       expect_named(
         x,
         c(
-          names(test_occdf),
+          names(test_data),
           "id",
           "n_bins",
           "bin_assignment",
@@ -341,42 +341,42 @@ test_that("user can pass custom function to method 'point'", {
   )
 })
 
-test_that("wrong input for occdf", {
+test_that("wrong input for data", {
   # Snapshots are slightly different in older versions of R
   skip_if(getRversion() < "4.3.0")
 
-  # "occdf" must be a non-empty dataframe and must be provided
-  expect_snapshot(bin_time(occdf = c(50, 20, 10)), error = TRUE)
+  # "data" must be a non-empty dataframe and must be provided
+  expect_snapshot(bin_time(data = c(50, 20, 10)), error = TRUE)
   expect_snapshot(bin_time(bins = c(50, 20, 10)), error = TRUE)
   expect_snapshot(
-    bin_time(occdf = data.frame(), bins = c(50, 20, 10)),
+    bin_time(data = data.frame(), bins = c(50, 20, 10)),
     error = TRUE
   )
   expect_snapshot(
-    bin_time(occdf = data.frame(), bins = data.frame(), method = "mid"),
+    bin_time(data = data.frame(), bins = data.frame(), method = "mid"),
     error = TRUE
   )
   expect_snapshot(
-    bin_time(occdf = data.frame(), bins = data.frame(), method = "mid"),
+    bin_time(data = data.frame(), bins = data.frame(), method = "mid"),
     error = TRUE
   )
   expect_snapshot(
-    bin_time(occdf = test_occdf, bins = data.frame(), method = "mid"),
+    bin_time(data = test_data, bins = data.frame(), method = "mid"),
     error = TRUE
   )
   expect_snapshot(
-    bin_time(occdf = test_occdf, bins = data.frame(), method = "mid"),
+    bin_time(data = test_data, bins = data.frame(), method = "mid"),
     error = TRUE
   )
 
   # dataframe that doesn't have the expected columns
   expect_snapshot(
-    bin_time(bins = mtcars, occdf = c(50, 20, 10)),
+    bin_time(bins = mtcars, data = c(50, 20, 10)),
     error = TRUE
   )
 
-  # max must be greater than min in bins and occdf
-  occdf <- data.frame(
+  # max must be greater than min in bins and data
+  data <- data.frame(
     name = c("occ1", "occ2", "occ3"),
     min_ma = c(0, 10, 5),
     max_ma = c(10, 9, 3)
@@ -386,9 +386,9 @@ test_that("wrong input for occdf", {
     min_ma = c(0, 8, 10),
     max_ma = c(10, 9, 15)
   )
-  expect_snapshot(bin_time(occdf, bins = bins), error = TRUE)
+  expect_snapshot(bin_time(data, bins = bins), error = TRUE)
 
-  occdf <- data.frame(
+  data <- data.frame(
     name = c("occ1", "occ2", "occ3"),
     min_ma = c(0, 10, 5),
     max_ma = c(10, 11, 13)
@@ -398,11 +398,11 @@ test_that("wrong input for occdf", {
     min_ma = c(0, 10, 5),
     max_ma = c(10, 9, 3)
   )
-  expect_snapshot(bin_time(occdf, bins = bins), error = TRUE)
+  expect_snapshot(bin_time(data, bins = bins), error = TRUE)
 })
 
 test_that("wrong input for method", {
-  occdf <- tetrapods[1:5, ]
+  data <- tetrapods[1:5, ]
   bins <- data.frame(
     bin = 1:54,
     max_ma = seq(10, 540, 10),
@@ -410,13 +410,13 @@ test_that("wrong input for method", {
   )
 
   expect_snapshot(
-    bin_time(occdf = occdf, bins = bins, method = "foo"),
+    bin_time(data = data, bins = bins, method = "foo"),
     error = TRUE
   )
 })
 
 test_that("wrong input for reps", {
-  occdf <- tetrapods[1:5, ]
+  data <- tetrapods[1:5, ]
   bins <- data.frame(
     bin = 1:54,
     max_ma = seq(10, 540, 10),
@@ -424,13 +424,13 @@ test_that("wrong input for reps", {
   )
 
   expect_snapshot(
-    bin_time(occdf = occdf, bins = bins, method = "random", reps = TRUE),
+    bin_time(data = data, bins = bins, method = "random", reps = TRUE),
     error = TRUE
   )
 })
 
 test_that("wrong input for fun", {
-  occdf <- tetrapods[1:5, ]
+  data <- tetrapods[1:5, ]
   bins <- data.frame(
     bin = 1:54,
     max_ma = seq(10, 540, 10),
@@ -440,7 +440,7 @@ test_that("wrong input for fun", {
   # "fun" must be a function
   expect_snapshot(
     bin_time(
-      occdf = occdf,
+      data = data,
       bins = bins,
       method = "point",
       fun = NULL
@@ -449,7 +449,7 @@ test_that("wrong input for fun", {
   )
   expect_snapshot(
     bin_time(
-      occdf = occdf,
+      data = data,
       bins = bins,
       method = "point",
       fun = 1
@@ -460,7 +460,7 @@ test_that("wrong input for fun", {
   # "x" shouldn't be provided
   expect_snapshot(
     bin_time(
-      occdf = occdf,
+      data = data,
       bins = bins,
       method = "point",
       fun = dnorm,
@@ -472,7 +472,7 @@ test_that("wrong input for fun", {
   # "test" is an invalid arg
   expect_snapshot(
     bin_time(
-      occdf = occdf,
+      data = data,
       bins = bins,
       method = "point",
       fun = dnorm,
@@ -484,7 +484,7 @@ test_that("wrong input for fun", {
   # multiple invalid args
   expect_snapshot(
     bin_time(
-      occdf = occdf,
+      data = data,
       bins = bins,
       method = "point",
       fun = dnorm,
@@ -496,7 +496,7 @@ test_that("wrong input for fun", {
 })
 
 test_that("errors in data for min and max age", {
-  occdf <- tetrapods[1:5, ]
+  data <- tetrapods[1:5, ]
   bins <- data.frame(
     bin = 1:54,
     max_ma = seq(10, 540, 10),
@@ -504,21 +504,21 @@ test_that("errors in data for min and max age", {
   )
 
   # Min age in data cannot be less than min age of bins
-  occdf$min_ma[1] <- -5000
-  expect_snapshot(bin_time(occdf = occdf, bins = bins), error = TRUE)
+  data$min_ma[1] <- -5000
+  expect_snapshot(bin_time(data = data, bins = bins), error = TRUE)
 
   # Max age in data cannot be less than max age of bins
-  occdf$max_ma[1] <- 5000
-  expect_snapshot(bin_time(occdf = occdf, bins = bins), error = TRUE)
+  data$max_ma[1] <- 5000
+  expect_snapshot(bin_time(data = data, bins = bins), error = TRUE)
 
   # Min or max age cannot have missing values
-  occdf$max_ma[1] <- NA
-  expect_snapshot(bin_time(occdf = occdf, bins = bins), error = TRUE)
+  data$max_ma[1] <- NA
+  expect_snapshot(bin_time(data = data, bins = bins), error = TRUE)
 })
 
 # TODO: shouldn't this error?
 # test_that("arg 'fun' is only used if method is 'point'", {
-#   occdf <- tetrapods[1:5, ]
+#   data <- tetrapods[1:5, ]
 #   bins <- data.frame(
 #     bin = 1:54,
 #     max_ma = seq(10, 540, 10),
@@ -526,14 +526,14 @@ test_that("errors in data for min and max age", {
 #   )
 
 #   expect_snapshot(
-#     bin_time(occdf = occdf, bins = bins, method = "random", fun = dnorm),
+#     bin_time(data = data, bins = bins, method = "random", fun = dnorm),
 #     error = TRUE
 #   )
 # })
 
 # TODO: shouldn't this error?
 # test_that("arg 'reps' is only used if method is 'point' or 'random'", {
-#   occdf <- tetrapods[1:5, ]
+#   data <- tetrapods[1:5, ]
 #   bins <- data.frame(
 #     bin = 1:54,
 #     max_ma = seq(10, 540, 10),
@@ -541,22 +541,22 @@ test_that("errors in data for min and max age", {
 #   )
 
 #   expect_snapshot(
-#     bin_time(occdf = occdf, bins = bins, method = "all", reps = 10),
+#     bin_time(data = data, bins = bins, method = "all", reps = 10),
 #     error = TRUE
 #   )
 # })
 
 test_that("bin_time errors with unnamed args", {
   expect_snapshot(
-    bin_time(occdf = test_occdf, test_bins, method = "majority"),
+    bin_time(data = test_data, test_bins, method = "majority"),
     error = TRUE
   )
-  expect_snapshot(bin_time(test_occdf, test_bins, "majority"), error = TRUE)
+  expect_snapshot(bin_time(test_data, test_bins, "majority"), error = TRUE)
 
   # Can't pass extra unnamed args
   expect_snapshot(
     bin_time(
-      occdf = test_occdf,
+      data = test_data,
       bins = test_bins,
       method = "point",
       reps = 5,

--- a/tests/testthat/test-group_apply.R
+++ b/tests/testthat/test-group_apply.R
@@ -1,8 +1,8 @@
 test_that("group_apply() basic behavior", {
-  occdf <- tetrapods[1:50, ]
+  data <- tetrapods[1:50, ]
 
   expect_equal(
-    group_apply(occdf = occdf, group = "cc", fun = nrow),
+    group_apply(data = data, group = "cc", fun = nrow),
     data.frame(
       nrow = c(1, 5, 6, 35, 3),
       cc = c("CA", "RU", "UK", "US", "ZA")
@@ -15,11 +15,11 @@ test_that("group_apply() basic behavior", {
   # several groups
   # fmt: skip
   expect_equal(
-    group_apply(occdf = occdf, group = c("collection_no", "cc"), fun = nrow),
+    group_apply(data = data, group = c("collection_no", "cc"), fun = nrow),
     data.frame(
       nrow = c(1, 5, 4, 2, 1, 1, 1, 1, 1, 9, 6, 6, 3, 6, 1, 1, 1),
       collection_no = c(
-        "13219", "22644", "22725", "22726", "12943", "13044", "13046", "13048", "13049", 
+        "13219", "22644", "22725", "22726", "12943", "13044", "13046", "13048", "13049",
         "13080", "13257", "13947", "22635", "22714", "13004", "13043", "13083"
       ),
       cc = c("CA", "RU", "UK", "UK", rep("US", 10), "ZA", "ZA", "ZA")
@@ -27,7 +27,7 @@ test_that("group_apply() basic behavior", {
   )
 })
 
-test_that("error handling for argument 'occdf'", {
+test_that("error handling for argument 'data'", {
   # Snapshots are slightly different in older versions of R
   skip_if(getRversion() < "4.3.0")
 
@@ -36,52 +36,52 @@ test_that("error handling for argument 'occdf'", {
     error = TRUE
   )
   expect_snapshot(
-    group_apply(occdf = 1, group = "cc", fun = nrow),
+    group_apply(data = 1, group = "cc", fun = nrow),
     error = TRUE
   )
   expect_snapshot(
-    group_apply(occdf = data.frame(), group = "cc", fun = nrow),
+    group_apply(data = data.frame(), group = "cc", fun = nrow),
     error = TRUE
   )
 })
 
 test_that("piping and not piping the first argument give the same result", {
-  occdf <- tetrapods[1:50, ]
+  data <- tetrapods[1:50, ]
 
   expect_equal(
-    group_apply(occdf, group = "cc", fun = nrow),
-    occdf |> group_apply(group = "cc", fun = nrow)
+    group_apply(data, group = "cc", fun = nrow),
+    data |> group_apply(group = "cc", fun = nrow)
   )
 })
 
 test_that("group_apply errors with unnamed args", {
-  occdf <- tetrapods[1:50, ]
+  data <- tetrapods[1:50, ]
 
-  expect_snapshot(group_apply(occdf, group = "cc", nrow), error = TRUE)
-  expect_snapshot(group_apply(occdf, "cc", nrow), error = TRUE)
+  expect_snapshot(group_apply(data, group = "cc", nrow), error = TRUE)
+  expect_snapshot(group_apply(data, "cc", nrow), error = TRUE)
   expect_snapshot(
-    group_apply(occdf, "cc", fun = tax_range_time, "family"),
+    group_apply(data, "cc", fun = tax_range_time, "family"),
     error = TRUE
   )
 
   # `name` isn't a proper argument of `group_apply()` but we still catch that it is named
   expect_snapshot(
-    group_apply(occdf, "cc", fun = tax_range_time, name = "family"),
+    group_apply(data, "cc", fun = tax_range_time, name = "family"),
     error = TRUE
   )
 })
 
 test_that("group_apply() accepts functions that return less or more rows than in the input", {
-  occdf <- tetrapods[1:100, ]
-  occdf <- subset(occdf, !is.na(genus))
+  data <- tetrapods[1:100, ]
+  data <- subset(data, !is.na(genus))
   expect_equal(
-    nrow(group_apply(occdf = occdf, group = "cc", fun = tax_range_time)),
+    nrow(group_apply(data = data, group = "cc", fun = tax_range_time)),
     48
   )
   expect_equal(
     nrow(
       group_apply(
-        occdf = occdf,
+        data = data,
         group = "cc",
         fun = tax_range_time,
         name = "family"
@@ -92,7 +92,7 @@ test_that("group_apply() accepts functions that return less or more rows than in
   expect_equal(
     nrow(
       group_apply(
-        occdf = occdf,
+        data = data,
         group = c("collection_no", "cc"),
         fun = tax_range_time
       )
@@ -103,7 +103,7 @@ test_that("group_apply() accepts functions that return less or more rows than in
   # can return no rows at all
   expect_null(
     group_apply(
-      occdf = occdf,
+      data = data,
       group = "collection_no",
       fun = tax_check,
       verbose = FALSE
@@ -112,25 +112,25 @@ test_that("group_apply() accepts functions that return less or more rows than in
 })
 
 test_that("group_apply() puts groups last", {
-  occdf <- tetrapods[1:100, ]
-  occdf <- subset(occdf, !is.na(genus))
+  data <- tetrapods[1:100, ]
+  data <- subset(data, !is.na(genus))
 
   # Single group
   expect_named(
-    group_apply(occdf = occdf, group = "cc", fun = nrow),
+    group_apply(data = data, group = "cc", fun = nrow),
     c("nrow", "cc")
   )
 
   # Several groups
   expect_named(
-    group_apply(occdf = occdf, group = c("cc", "formation"), fun = nrow),
+    group_apply(data = data, group = c("cc", "formation"), fun = nrow),
     c("nrow", "cc", "formation")
   )
 
   # Hits the "list" branch in group_apply()
   expect_named(
     group_apply(
-      occdf = occdf,
+      data = data,
       group = "collection_no",
       fun = tax_unique,
       genus = "genus",
@@ -143,7 +143,7 @@ test_that("group_apply() puts groups last", {
   )
   expect_named(
     group_apply(
-      occdf = occdf,
+      data = data,
       group = c("cc", "formation"),
       fun = tax_range_time
     ),
@@ -164,27 +164,27 @@ test_that("error handling for argument 'group'", {
   # Snapshots are slightly different in older versions of R
   skip_if(getRversion() < "4.3.0")
 
-  occdf <- tetrapods[1:50, ]
-  expect_snapshot(group_apply(occdf = occdf, fun = nrow), error = TRUE)
+  data <- tetrapods[1:50, ]
+  expect_snapshot(group_apply(data = data, fun = nrow), error = TRUE)
   expect_snapshot(
-    group_apply(occdf = occdf, group = NULL, fun = nrow),
+    group_apply(data = data, group = NULL, fun = nrow),
     error = TRUE
   )
   expect_snapshot(
-    group_apply(occdf = occdf, group = "foo", fun = nrow),
+    group_apply(data = data, group = "foo", fun = nrow),
     error = TRUE
   )
   expect_snapshot(
-    group_apply(occdf = occdf, group = 1, fun = nrow),
+    group_apply(data = data, group = 1, fun = nrow),
     error = TRUE
   )
   expect_snapshot(
-    group_apply(occdf = occdf, group = c("cc", "foobar"), fun = nrow),
+    group_apply(data = data, group = c("cc", "foobar"), fun = nrow),
     error = TRUE
   )
   expect_snapshot(
     group_apply(
-      occdf = occdf,
+      data = data,
       group = c("cc", "foobar", "foobar2"),
       fun = nrow
     ),
@@ -200,7 +200,7 @@ test_that("error handling for argument 'group'", {
   # Fixed in https://github.com/palaeoverse/palaeoverse/pull/181
   foo <- mtcars
   expect_snapshot(
-    group_apply(occdf = occdf, group = c("cc", "foo"), fun = nrow),
+    group_apply(data = data, group = c("cc", "foo"), fun = nrow),
     error = TRUE
   )
 })
@@ -209,13 +209,13 @@ test_that("error handling for argument 'fun'", {
   # Snapshots are slightly different in older versions of R
   skip_if(getRversion() < "4.3.0")
 
-  occdf <- tetrapods
-  occdf <- subset(occdf, !is.na(genus))
+  data <- tetrapods
+  data <- subset(data, !is.na(genus))
 
   # quoted function name isn't accepted
   expect_snapshot(
     group_apply(
-      occdf = occdf,
+      data = data,
       group = "cc",
       fun = "tax_range_time"
     ),
@@ -223,13 +223,13 @@ test_that("error handling for argument 'fun'", {
   )
   # unknown function
   expect_snapshot(
-    group_apply(occdf = occdf, group = "cc", fun = foobar),
+    group_apply(data = data, group = "cc", fun = foobar),
     error = TRUE
   )
   # one unknown arg
   expect_snapshot(
     group_apply(
-      occdf = occdf,
+      data = data,
       group = "cc",
       fun = tax_range_time,
       not_an_argument = "test"
@@ -239,7 +239,7 @@ test_that("error handling for argument 'fun'", {
   # multiple unknown args
   expect_snapshot(
     group_apply(
-      occdf = occdf,
+      data = data,
       group = "cc",
       fun = tax_range_time,
       not_an_argument1 = "test",

--- a/tests/testthat/test-look_up.R
+++ b/tests/testthat/test-look_up.R
@@ -30,7 +30,7 @@ colnames(test_look_up) <- c("case", "early_interval", "late_interval")
 test_that("basic behavior works", {
   expect_equal(
     look_up(
-      occdf = test_look_up[
+      data = test_look_up[
         test_look_up$case %in% c("both_stages_equal", "two_stages_range"),
       ]
     ),
@@ -48,19 +48,19 @@ test_that("basic behavior works", {
 })
 
 test_that("piping and not piping the first argument give the same result", {
-  occdf <- test_look_up[
+  data <- test_look_up[
     test_look_up$case %in% c("both_stages_equal", "two_stages_range"),
   ]
   expect_equal(
-    occdf |> look_up(),
-    look_up(occdf)
+    data |> look_up(),
+    look_up(data)
   )
 })
 
 test_that("look_up errors with unnamed args", {
   expect_snapshot(look_up(test_look_up, "early_interval"), error = TRUE)
   expect_snapshot(
-    look_up(occdf = test_look_up, "early_interval"),
+    look_up(data = test_look_up, "early_interval"),
     error = TRUE
   )
   expect_snapshot(
@@ -73,7 +73,7 @@ test_that("look_up errors with unnamed args", {
   )
 })
 
-test_that("wrong input for argument 'occdf'", {
+test_that("wrong input for argument 'data'", {
   expect_snapshot(look_up(1), error = TRUE)
   expect_snapshot(look_up(NA), error = TRUE)
   expect_snapshot(look_up(NULL), error = TRUE)
@@ -82,7 +82,7 @@ test_that("wrong input for argument 'occdf'", {
 test_that("look_up() warns if late interval is NA, empty, or blank", {
   expect_warning(
     expect_equal(
-      look_up(occdf = test_look_up[test_look_up$case == "late_na", ]),
+      look_up(data = test_look_up[test_look_up$case == "late_na", ]),
       data.frame(
         case = "late_na",
         early_interval = "Asselian",
@@ -99,7 +99,7 @@ test_that("look_up() warns if late interval is NA, empty, or blank", {
   )
   expect_warning(
     expect_equal(
-      look_up(occdf = test_look_up[test_look_up$case == "late_empty", ]),
+      look_up(data = test_look_up[test_look_up$case == "late_empty", ]),
       data.frame(
         case = "late_empty",
         early_interval = "Asselian",
@@ -116,7 +116,7 @@ test_that("look_up() warns if late interval is NA, empty, or blank", {
   )
   expect_warning(
     expect_equal(
-      look_up(occdf = test_look_up[test_look_up$case == "late_blank", ]),
+      look_up(data = test_look_up[test_look_up$case == "late_blank", ]),
       data.frame(
         case = "late_blank",
         early_interval = "Asselian",
@@ -136,7 +136,7 @@ test_that("look_up() warns if late interval is NA, empty, or blank", {
 test_that("look_up() warns if some intervals couldn't be matched", {
   expect_warning(
     expect_equal(
-      look_up(occdf = test_look_up[test_look_up$case == "key_only", ]),
+      look_up(data = test_look_up[test_look_up$case == "key_only", ]),
       data.frame(
         case = "key_only",
         early_interval = "Missourian",
@@ -159,7 +159,7 @@ test_that("arguments 'early_interval' and 'late_interval' work", {
 
   expect_equal(
     look_up(
-      occdf = dat[dat$case %in% c("both_stages_equal", "two_stages_range"), ],
+      data = dat[dat$case %in% c("both_stages_equal", "two_stages_range"), ],
       early_interval = "early",
       late_interval = "late"
     ),
@@ -176,36 +176,36 @@ test_that("arguments 'early_interval' and 'late_interval' work", {
   )
 
   # either one or both interval columns are not found in the data
-  expect_snapshot(look_up(occdf = dat), error = TRUE)
+  expect_snapshot(look_up(data = dat), error = TRUE)
   expect_snapshot(
-    look_up(occdf = dat, early_interval = "early"),
+    look_up(data = dat, early_interval = "early"),
     error = TRUE
   )
-  expect_snapshot(look_up(occdf = dat, late_interval = "late"), error = TRUE)
+  expect_snapshot(look_up(data = dat, late_interval = "late"), error = TRUE)
 
   # wrong input type
-  expect_snapshot(look_up(occdf = dat, early_interval = 1), error = TRUE)
-  expect_snapshot(look_up(occdf = dat, early_interval = NA), error = TRUE)
+  expect_snapshot(look_up(data = dat, early_interval = 1), error = TRUE)
+  expect_snapshot(look_up(data = dat, early_interval = NA), error = TRUE)
   expect_snapshot(
-    look_up(occdf = dat, early_interval = c("a", "b")),
+    look_up(data = dat, early_interval = c("a", "b")),
     error = TRUE
   )
   expect_snapshot(
-    look_up(occdf = dat, early_interval = "early", late_interval = 1),
+    look_up(data = dat, early_interval = "early", late_interval = 1),
     error = TRUE
   )
   expect_snapshot(
-    look_up(occdf = dat, early_interval = "early", late_interval = NA),
+    look_up(data = dat, early_interval = "early", late_interval = NA),
     error = TRUE
   )
   expect_snapshot(
-    look_up(occdf = dat, early_interval = "early", late_interval = c("a", "b")),
+    look_up(data = dat, early_interval = "early", late_interval = c("a", "b")),
     error = TRUE
   )
 })
 
 test_that("argument 'int_key' works", {
-  occdf <- test_look_up[test_look_up$case %in% c("key_only", "precambrian"), ]
+  data <- test_look_up[test_look_up$case %in% c("key_only", "precambrian"), ]
 
   # A custom int_key assigns its own stage names. Intervals missing from the
   # key still fall back to GTS, e.g. the late Gzhelian stage of `key_only`,
@@ -216,7 +216,7 @@ test_that("argument 'int_key' works", {
     late_stage = c("bar1", "bar2")
   )
   expect_equal(
-    look_up(occdf, int_key = my_interval),
+    look_up(data, int_key = my_interval),
     data.frame(
       case = c("key_only", "precambrian"),
       early_interval = c("Missourian", "Ediacaran"),
@@ -231,13 +231,13 @@ test_that("argument 'int_key' works", {
   )
 
   # wrong input for int_key
-  expect_snapshot(look_up(occdf, int_key = 1), error = TRUE)
-  expect_snapshot(look_up(occdf, int_key = c("a", "b")), error = TRUE)
+  expect_snapshot(look_up(data, int_key = 1), error = TRUE)
+  expect_snapshot(look_up(data, int_key = c("a", "b")), error = TRUE)
 
   # missing column(s) in int_key
   expect_snapshot(
     look_up(
-      occdf,
+      data,
       int_key = data.frame(
         interval_name = c("Induan", "Asselian"),
         early_stage = c("foo1", "foo2")
@@ -247,7 +247,7 @@ test_that("argument 'int_key' works", {
   )
   expect_snapshot(
     look_up(
-      occdf,
+      data,
       int_key = data.frame(
         interval_name = c("Induan", "Asselian"),
         late_stage = c("foo1", "foo2")
@@ -258,7 +258,7 @@ test_that("argument 'int_key' works", {
   # wrong column type
   expect_snapshot(
     look_up(
-      occdf,
+      data,
       int_key = data.frame(
         interval_name = c("Induan", "Asselian"),
         early_stage = 1:2,
@@ -270,7 +270,7 @@ test_that("argument 'int_key' works", {
   # max_ma and min_ma must be numeric
   expect_snapshot(
     look_up(
-      occdf,
+      data,
       int_key = data.frame(
         interval_name = c("Induan", "Asselian"),
         early_stage = c("foo1", "foo2"),
@@ -282,7 +282,7 @@ test_that("argument 'int_key' works", {
   )
   expect_snapshot(
     look_up(
-      occdf,
+      data,
       int_key = data.frame(
         interval_name = c("Induan", "Asselian"),
         early_stage = c("foo1", "foo2"),
@@ -295,7 +295,7 @@ test_that("argument 'int_key' works", {
 })
 
 test_that("int_key works with columns 'min_ma' and 'max_ma'", {
-  occdf <- test_look_up[
+  data <- test_look_up[
     test_look_up$case %in% c("both_stages_equal", "key_only", "unmatchable"),
   ]
 
@@ -310,7 +310,7 @@ test_that("int_key works with columns 'min_ma' and 'max_ma'", {
   # `unmatchable` is in neither the key nor GTS, so it stays unassigned and warns
   expect_warning(
     expect_equal(
-      look_up(occdf, int_key = custom_key, assign_with_GTS = FALSE),
+      look_up(data, int_key = custom_key, assign_with_GTS = FALSE),
       data.frame(
         case = c("both_stages_equal", "key_only", "unmatchable"),
         early_interval = c("Capitanian", "Missourian", "Meso-archean"),
@@ -328,12 +328,12 @@ test_that("int_key works with columns 'min_ma' and 'max_ma'", {
 })
 
 test_that("argument 'assign_with_GTS' works", {
-  occdf <- test_look_up[
+  data <- test_look_up[
     test_look_up$case %in%
       c("both_stages_equal", "two_stages_range", "gts_epoch"),
   ]
   expect_equal(
-    look_up(occdf, assign_with_GTS = "GTS2020"),
+    look_up(data, assign_with_GTS = "GTS2020"),
     data.frame(
       case = c("both_stages_equal", "two_stages_range", "gts_epoch"),
       early_interval = c("Capitanian", "Induan", "Cisuralian"),
@@ -347,7 +347,7 @@ test_that("argument 'assign_with_GTS' works", {
     )
   )
   expect_equal(
-    look_up(occdf, assign_with_GTS = "GTS2012"),
+    look_up(data, assign_with_GTS = "GTS2012"),
     data.frame(
       case = c("both_stages_equal", "two_stages_range", "gts_epoch"),
       early_interval = c("Capitanian", "Induan", "Cisuralian"),
@@ -364,10 +364,10 @@ test_that("argument 'assign_with_GTS' works", {
   # with assign_with_GTS = FALSE, only the int_key is used: no GTS fallback and
   # no age columns. `Gzhelian` is not an interval name in the key, so the late
   # stage of `key_only` stays unassigned and a warning is raised.
-  occdf <- test_look_up[test_look_up$case %in% c("key_only", "precambrian"), ]
+  data <- test_look_up[test_look_up$case %in% c("key_only", "precambrian"), ]
   expect_warning(
     expect_equal(
-      look_up(occdf, int_key = interval_key, assign_with_GTS = FALSE),
+      look_up(data, int_key = interval_key, assign_with_GTS = FALSE),
       data.frame(
         case = c("key_only", "precambrian"),
         early_interval = c("Missourian", "Ediacaran"),
@@ -382,16 +382,16 @@ test_that("argument 'assign_with_GTS' works", {
 
   # input check
   expect_snapshot(
-    look_up(occdf, int_key = interval_key, assign_with_GTS = "foo"),
+    look_up(data, int_key = interval_key, assign_with_GTS = "foo"),
     error = TRUE
   )
 
   # TODO: update docs to mention that we can't have assign_with_GTS = FALSE
   # and int_key = FALSE at the same time
-  expect_snapshot(look_up(occdf, assign_with_GTS = FALSE), error = TRUE)
+  expect_snapshot(look_up(data, assign_with_GTS = FALSE), error = TRUE)
 
-  expect_snapshot(look_up(occdf, assign_with_GTS = 1), error = TRUE)
-  expect_snapshot(look_up(occdf, assign_with_GTS = "foo"), error = TRUE)
+  expect_snapshot(look_up(data, assign_with_GTS = 1), error = TRUE)
+  expect_snapshot(look_up(data, assign_with_GTS = "foo"), error = TRUE)
 })
 
 test_that("argument 'return_unassigned' works", {
@@ -425,12 +425,12 @@ test_that("pre-Phanerozoic intervals are handled without error", {
   # than causing an error. `Meso-archean` is absent from GTS entirely. Both end
   # up unassigned (with a warning), but the function still returns a well-formed
   # dataframe.
-  occdf <- test_look_up[
+  data <- test_look_up[
     test_look_up$case %in% c("precambrian", "unmatchable"),
   ]
   expect_warning(
     expect_equal(
-      look_up(occdf, assign_with_GTS = "GTS2012", int_key = FALSE),
+      look_up(data, assign_with_GTS = "GTS2012", int_key = FALSE),
       data.frame(
         case = c("precambrian", "unmatchable"),
         early_interval = c("Ediacaran", "Meso-archean"),
@@ -448,14 +448,14 @@ test_that("pre-Phanerozoic intervals are handled without error", {
 })
 
 test_that("'early_interval' and 'late_interval' can point to the same column", {
-  occdf <- test_look_up[
+  data <- test_look_up[
     test_look_up$case %in% c("both_stages_equal", "gts_epoch"),
     c("case", "early_interval")
   ]
-  colnames(occdf) <- c("case", "interval")
+  colnames(data) <- c("case", "interval")
 
   expect_equal(
-    look_up(occdf, early_interval = "interval", late_interval = "interval"),
+    look_up(data, early_interval = "interval", late_interval = "interval"),
     data.frame(
       case = c("both_stages_equal", "gts_epoch"),
       interval = c("Capitanian", "Cisuralian"),
@@ -470,13 +470,13 @@ test_that("'early_interval' and 'late_interval' can point to the same column", {
 
   # Ensure that we get the same results when early_interval and late_interval
   # are equal
-  occdf <- data.frame(
+  data <- data.frame(
     case = c("both_stages_equal", "gts_epoch"),
     early_interval = c("Capitanian", "Cisuralian"),
     late_interval = c("Capitanian", "Cisuralian")
   )
   expect_equal(
-    look_up(occdf),
+    look_up(data),
     data.frame(
       case = c("both_stages_equal", "gts_epoch"),
       early_interval = c("Capitanian", "Cisuralian"),

--- a/tests/testthat/test-palaeorotate.R
+++ b/tests/testthat/test-palaeorotate.R
@@ -1,24 +1,24 @@
-test_that("arg 'occdf' works", {
+test_that("arg 'data' works", {
   skip_if_offline(host = "gws.gplates.org")
   skip_if_not_installed("vcr")
 
-  occdf <- data.frame(
+  data <- data.frame(
     lng = c(2, -103, -66),
     lat = c(46, 35, -7),
     age = c(88, 125, 300)
   )
 
-  # A valid occdf returns the same number of rows
+  # A valid data returns the same number of rows
   vcr::use_cassette("palaeorotate-paleomap", {
-    paleomap <- palaeorotate(occdf = occdf, model = "PALEOMAP")
+    paleomap <- palaeorotate(data = data, model = "PALEOMAP")
   })
   expect_equal(nrow(paleomap), 3)
 
   # input checks
-  expect_snapshot(palaeorotate(occdf = 10), error = TRUE)
-  expect_snapshot(palaeorotate(occdf = NA), error = TRUE)
+  expect_snapshot(palaeorotate(data = 10), error = TRUE)
+  expect_snapshot(palaeorotate(data = NA), error = TRUE)
   expect_snapshot(
-    palaeorotate(occdf = data.frame(lng = 10, lat = 5)),
+    palaeorotate(data = data.frame(lng = 10, lat = 5)),
     error = TRUE
   )
 })
@@ -27,43 +27,43 @@ test_that("piping and not piping the first argument give the same result", {
   skip_if_offline(host = "gws.gplates.org")
   skip_if_not_installed("vcr")
 
-  occdf <- data.frame(
+  data <- data.frame(
     lng = c(2, -103, -66),
     lat = c(46, 35, -7),
     age = c(88, 125, 300)
   )
 
   vcr::use_cassette("palaeorotate-paleomap", {
-    piped <- occdf |> palaeorotate(model = "PALEOMAP")
+    piped <- data |> palaeorotate(model = "PALEOMAP")
   })
   vcr::use_cassette("palaeorotate-paleomap", {
-    not_piped <- palaeorotate(occdf, model = "PALEOMAP")
+    not_piped <- palaeorotate(data, model = "PALEOMAP")
   })
 
   expect_equal(piped, not_piped)
 })
 
 test_that("palaeorotate errors with unnamed args", {
-  occdf <- data.frame(lng = c(2, -103), lat = c(46, 35), age = c(88, 125))
-  expect_snapshot(palaeorotate(occdf, "lng"), error = TRUE)
-  expect_snapshot(palaeorotate(occdf = occdf, "lng"), error = TRUE)
-  expect_snapshot(palaeorotate(occdf, "lng", "lat"), error = TRUE)
-  expect_snapshot(palaeorotate(occdf, "lng", lat = "lat"), error = TRUE)
+  data <- data.frame(lng = c(2, -103), lat = c(46, 35), age = c(88, 125))
+  expect_snapshot(palaeorotate(data, "lng"), error = TRUE)
+  expect_snapshot(palaeorotate(data = data, "lng"), error = TRUE)
+  expect_snapshot(palaeorotate(data, "lng", "lat"), error = TRUE)
+  expect_snapshot(palaeorotate(data, "lng", lat = "lat"), error = TRUE)
 })
 
-test_that("Large occdf inputs are chunked before being sent to the API", {
+test_that("Large data inputs are chunked before being sent to the API", {
   skip_if_offline(host = "gws.gplates.org")
   skip_if_not_installed("vcr")
 
   set.seed(0)
-  big_occdf <- data.frame(
+  big_data <- data.frame(
     lng = runif(1500, -180, 180),
     lat = runif(1500, -90, 90),
     age = rep(100, 1500)
   )
   expect_warning(
     vcr::use_cassette("palaeorotate-paleomap-chunksize", {
-      paleomap <- palaeorotate(occdf = big_occdf, model = "PALEOMAP")
+      paleomap <- palaeorotate(data = big_data, model = "PALEOMAP")
     }),
     regexp = "Palaeocoordinates"
   )
@@ -72,45 +72,45 @@ test_that("Large occdf inputs are chunked before being sent to the API", {
 
 test_that("input checks for longitude", {
   expect_snapshot(
-    palaeorotate(occdf = data.frame(lng = 210, lat = 40, age = 25)),
+    palaeorotate(data = data.frame(lng = 210, lat = 40, age = 25)),
     error = TRUE
   )
   expect_snapshot(
-    palaeorotate(occdf = data.frame(lng = NA, lat = 40, age = 25)),
+    palaeorotate(data = data.frame(lng = NA, lat = 40, age = 25)),
     error = TRUE
   )
   expect_snapshot(
-    palaeorotate(occdf = data.frame(lng = "a", lat = 40, age = 25)),
+    palaeorotate(data = data.frame(lng = "a", lat = 40, age = 25)),
     error = TRUE
   )
 })
 
 test_that("input checks for latitude", {
   expect_snapshot(
-    palaeorotate(occdf = data.frame(lng = 160, lat = 200, age = 25)),
+    palaeorotate(data = data.frame(lng = 160, lat = 200, age = 25)),
     error = TRUE
   )
   expect_snapshot(
-    palaeorotate(occdf = data.frame(lng = 40, lat = NA, age = 25)),
+    palaeorotate(data = data.frame(lng = 40, lat = NA, age = 25)),
     error = TRUE
   )
   expect_snapshot(
-    palaeorotate(occdf = data.frame(lng = 40, lat = "a", age = 25)),
+    palaeorotate(data = data.frame(lng = 40, lat = "a", age = 25)),
     error = TRUE
   )
 })
 
 test_that("input checks values for age", {
   expect_snapshot(
-    palaeorotate(occdf = data.frame(lng = 160, lat = 40, age = -1)),
+    palaeorotate(data = data.frame(lng = 160, lat = 40, age = -1)),
     error = TRUE
   )
   expect_snapshot(
-    palaeorotate(occdf = data.frame(lng = 160, lat = 40, age = NA)),
+    palaeorotate(data = data.frame(lng = 160, lat = 40, age = NA)),
     error = TRUE
   )
   expect_snapshot(
-    palaeorotate(occdf = data.frame(lng = 160, lat = 40, age = "a")),
+    palaeorotate(data = data.frame(lng = 160, lat = 40, age = "a")),
     error = TRUE
   )
 })
@@ -119,14 +119,14 @@ test_that("arg 'lng' works", {
   skip_if_offline(host = "gws.gplates.org")
   skip_if_not_installed("vcr")
 
-  occdf <- data.frame(
+  data <- data.frame(
     longitude = c(2, -103, -66),
     lat = c(46, 35, -7),
     age = c(88, 125, 300)
   )
 
   vcr::use_cassette("palaeorotate-custom-lng", {
-    out <- palaeorotate(occdf = occdf, lng = "longitude")
+    out <- palaeorotate(data = data, lng = "longitude")
   })
   expect_equal(nrow(out), 3)
 })
@@ -135,14 +135,14 @@ test_that("arg 'lat' works", {
   skip_if_offline(host = "gws.gplates.org")
   skip_if_not_installed("vcr")
 
-  occdf <- data.frame(
+  data <- data.frame(
     lng = c(2, -103, -66),
     latitude = c(46, 35, -7),
     age = c(88, 125, 300)
   )
 
   vcr::use_cassette("palaeorotate-custom-lat", {
-    out <- palaeorotate(occdf = occdf, lat = "latitude")
+    out <- palaeorotate(data = data, lat = "latitude")
   })
   expect_equal(nrow(out), 3)
 })
@@ -151,14 +151,14 @@ test_that("arg 'age' works", {
   skip_if_offline(host = "gws.gplates.org")
   skip_if_not_installed("vcr")
 
-  occdf <- data.frame(
+  data <- data.frame(
     lng = c(2, -103, -66),
     lat = c(46, 35, -7),
     custom_age = c(88, 125, 300)
   )
 
   vcr::use_cassette("palaeorotate-custom-age", {
-    out <- palaeorotate(occdf = occdf, age = "custom_age")
+    out <- palaeorotate(data = data, age = "custom_age")
   })
   expect_equal(nrow(out), 3)
 })
@@ -169,7 +169,7 @@ test_that("arg 'model' works", {
   skip_on_cran()
   skip_if_not_installed("vcr")
 
-  occdf <- data.frame(
+  data <- data.frame(
     lng = c(2, -103, -66),
     lat = c(46, 35, -7),
     age = c(88, 125, 300)
@@ -178,13 +178,13 @@ test_that("arg 'model' works", {
   # --- point method ---
   # Multiple models return one set of palaeocoordinates per model
   vcr::use_cassette("palaeorotate-multi", {
-    multi <- palaeorotate(occdf = occdf, model = c("PALEOMAP", "GOLONKA"))
+    multi <- palaeorotate(data = data, model = c("PALEOMAP", "GOLONKA"))
   })
   # fmt: skip
   expect_named(
     multi,
     c(
-      "lng", "lat", "age", "p_lng_PALEOMAP", "p_lat_PALEOMAP", "p_lng_GOLONKA", 
+      "lng", "lat", "age", "p_lng_PALEOMAP", "p_lat_PALEOMAP", "p_lng_GOLONKA",
       "p_lat_GOLONKA", "range_p_lat", "max_dist"
     )
   )
@@ -200,14 +200,14 @@ test_that("arg 'model' works", {
   )
   expect_warning(
     vcr::use_cassette("palaeorotate-temporal", {
-      paleomap <- palaeorotate(occdf = outside, model = "GOLONKA")$p_lng
+      paleomap <- palaeorotate(data = outside, model = "GOLONKA")$p_lng
     }),
     regexp = "Palaeocoordinates"
   )
   expect_true(all(is.na(paleomap)))
 
   # Requesting several models still warns when occurrences exceed the range
-  occdf_old <- data.frame(
+  data_old <- data.frame(
     lng = c(2, -103, -66),
     lat = c(46, 35, -7),
     age = c(88, 125, 700)
@@ -215,7 +215,7 @@ test_that("arg 'model' works", {
   expect_warning(
     vcr::use_cassette("palaeorotate-multi-point", {
       palaeorotate(
-        occdf = occdf_old,
+        data = data_old,
         method = "point",
         model = c("GOLONKA", "PALEOMAP")
       )
@@ -228,7 +228,7 @@ test_that("arg 'model' works", {
   # This live call also caches the reconstruction files used by the
   # cassette-backed test below.
   grid_multi <- palaeorotate(
-    occdf = occdf,
+    data = data,
     method = "grid",
     model = c("PALEOMAP", "GOLONKA")
   )
@@ -242,7 +242,7 @@ test_that("arg 'model' works", {
   )
 
   # Occurrences beyond a model's temporal range return NA
-  occdf_grid <- data.frame(
+  data_grid <- data.frame(
     lng = c(2, -103, -66),
     lat = c(46, 35, -7),
     age = rep(700, 3)
@@ -250,7 +250,7 @@ test_that("arg 'model' works", {
   expect_warning(
     vcr::use_cassette("palaeorotate-grid-temporal", {
       grid_temporal <- palaeorotate(
-        occdf = occdf_grid,
+        data = data_grid,
         model = "GOLONKA",
         method = "grid"
       )
@@ -261,22 +261,22 @@ test_that("arg 'model' works", {
 
   # input checks
   expect_snapshot(
-    palaeorotate(occdf = occdf, method = "point", model = NA),
+    palaeorotate(data = data, method = "point", model = NA),
     error = TRUE
   )
   expect_snapshot(
-    palaeorotate(occdf = occdf, method = "point", model = character(0)),
+    palaeorotate(data = data, method = "point", model = character(0)),
     error = TRUE
   )
 
   # Previously available models have been removed
   expect_snapshot(
-    palaeorotate(occdf = occdf, method = "point", model = "MULLER2022"),
+    palaeorotate(data = data, method = "point", model = "MULLER2022"),
     error = TRUE
   )
   # Unknown models are rejected
   expect_snapshot(
-    palaeorotate(occdf = occdf, method = "point", model = "GPlates"),
+    palaeorotate(data = data, method = "point", model = "GPlates"),
     error = TRUE
   )
 })
@@ -287,7 +287,7 @@ test_that("arg 'method' works", {
   skip_on_cran()
   skip_if_not_installed("vcr")
 
-  occdf <- data.frame(
+  data <- data.frame(
     lng = c(2, -103, -66),
     lat = c(46, 35, -7),
     age = c(88, 125, 300)
@@ -295,25 +295,25 @@ test_that("arg 'method' works", {
 
   # The "point" method returns the same number of rows
   vcr::use_cassette("palaeorotate-paleomap", {
-    point <- palaeorotate(occdf = occdf, model = "PALEOMAP", method = "point")
+    point <- palaeorotate(data = data, model = "PALEOMAP", method = "point")
   })
   expect_equal(nrow(point), 3)
 
   # The "grid" method returns the same number of rows
   expect_equal(
-    nrow(palaeorotate(occdf = occdf, model = "PALEOMAP", method = "grid")),
+    nrow(palaeorotate(data = data, model = "PALEOMAP", method = "grid")),
     3
   )
 
   # input checks
-  expect_snapshot(palaeorotate(occdf = occdf, method = "foo"), error = TRUE)
-  expect_snapshot(palaeorotate(occdf = occdf, method = NA), error = TRUE)
+  expect_snapshot(palaeorotate(data = data, method = "foo"), error = TRUE)
+  expect_snapshot(palaeorotate(data = data, method = NA), error = TRUE)
   expect_snapshot(
-    palaeorotate(occdf = occdf, method = character(0)),
+    palaeorotate(data = data, method = character(0)),
     error = TRUE
   )
   expect_snapshot(
-    palaeorotate(occdf = occdf, method = c("point", "grid")),
+    palaeorotate(data = data, method = c("point", "grid")),
     error = TRUE
   )
 })
@@ -337,7 +337,7 @@ test_that("arg 'uncertainty' works", {
   expect_warning(
     vcr::use_cassette("palaeorotate-multi-outside-range", {
       paleomap <- palaeorotate(
-        occdf = outside,
+        data = outside,
         model = c("PALEOMAP", "GOLONKA"),
         uncertainty = TRUE
       )$max_dist
@@ -347,21 +347,21 @@ test_that("arg 'uncertainty' works", {
   expect_true(all(is.na(paleomap)))
 
   # --- grid method ---
-  occdf_grid <- data.frame(
+  data_grid <- data.frame(
     lng = c(2, -103, -66),
     lat = c(46, 35, -7),
     age = rep(700, 3)
   )
   # Ensure reconstruction files are cached before the cassette-backed call
   # invisible(palaeorotate(
-  #   occdf = data.frame(lng = c(2, -103), lat = c(46, 35), age = c(88, 125)),
+  #   data = data.frame(lng = c(2, -103), lat = c(46, 35), age = c(88, 125)),
   #   model = c("PALEOMAP", "GOLONKA"),
   #   method = "grid"
   # ))
   expect_warning(
     vcr::use_cassette("palaeorotate-grid-temporal-outside-range", {
       grid_temporal <- palaeorotate(
-        occdf = occdf_grid,
+        data = data_grid,
         model = c("PALEOMAP", "GOLONKA"),
         method = "grid",
         uncertainty = TRUE
@@ -374,21 +374,21 @@ test_that("arg 'uncertainty' works", {
   # input checks
   dat <- data.frame(lng = 110, lat = 40, age = 25)
   expect_snapshot(
-    palaeorotate(occdf = dat, uncertainty = "GOONTHEN"),
+    palaeorotate(data = dat, uncertainty = "GOONTHEN"),
     error = TRUE
   )
   expect_snapshot(
-    palaeorotate(occdf = dat, uncertainty = character(0)),
+    palaeorotate(data = dat, uncertainty = character(0)),
     error = TRUE
   )
-  expect_snapshot(palaeorotate(occdf = dat, uncertainty = 1), error = TRUE)
+  expect_snapshot(palaeorotate(data = dat, uncertainty = 1), error = TRUE)
 })
 
 test_that("arg 'round' works", {
   skip_if_offline(host = "gws.gplates.org")
   skip_if_not_installed("vcr")
 
-  occdf <- data.frame(
+  data <- data.frame(
     lng = c(2, -103, -66),
     lat = c(46, 35, -7),
     age = c(88, 125, 300)
@@ -396,15 +396,15 @@ test_that("arg 'round' works", {
 
   # Disabling rounding still returns palaeocoordinates for every occurrence
   vcr::use_cassette("palaeorotate-paleomap", {
-    paleomap <- palaeorotate(occdf = occdf, model = "PALEOMAP", round = NULL)
+    paleomap <- palaeorotate(data = data, model = "PALEOMAP", round = NULL)
   })
   expect_equal(nrow(paleomap), 3)
 
   # input checks
-  expect_snapshot(palaeorotate(occdf = occdf, round = TRUE), error = TRUE)
-  expect_snapshot(palaeorotate(occdf = occdf, round = NA), error = TRUE)
-  expect_snapshot(palaeorotate(occdf = occdf, round = numeric(0)), error = TRUE)
-  expect_snapshot(palaeorotate(occdf = occdf, round = 1:2), error = TRUE)
+  expect_snapshot(palaeorotate(data = data, round = TRUE), error = TRUE)
+  expect_snapshot(palaeorotate(data = data, round = NA), error = TRUE)
+  expect_snapshot(palaeorotate(data = data, round = numeric(0)), error = TRUE)
+  expect_snapshot(palaeorotate(data = data, round = 1:2), error = TRUE)
 })
 
 test_that("good error message if GPlates or Zenodo are not available", {
@@ -413,19 +413,19 @@ test_that("good error message if GPlates or Zenodo are not available", {
   local_mocked_bindings(
     nslookup = function(...) stop("foo")
   )
-  occdf <- data.frame(
+  data <- data.frame(
     lng = c(2, -103, -66),
     lat = c(46, 35, -7),
     age = c(88, 125, 300)
   )
   # GPlates
   expect_snapshot(
-    palaeorotate(occdf = occdf, model = "PALEOMAP"),
+    palaeorotate(data = data, model = "PALEOMAP"),
     error = TRUE
   )
   # Zenodo
   expect_snapshot(
-    palaeorotate(occdf = occdf, model = "PALEOMAP", method = "grid"),
+    palaeorotate(data = data, model = "PALEOMAP", method = "grid"),
     error = TRUE
   )
 })

--- a/tests/testthat/test-tax_certainty.R
+++ b/tests/testthat/test-tax_certainty.R
@@ -1,121 +1,121 @@
 test_that("throws error for missing required arguments", {
-  expect_snapshot(tax_certainty(taxdf = 1, name = "foo"), error = TRUE)
+  expect_snapshot(tax_certainty(data = 1, name = "foo"), error = TRUE)
   skip_if(getRversion() < "4.3.0")
   expect_snapshot(tax_certainty(), error = TRUE)
-  expect_snapshot(tax_certainty(taxdf = tetrapods), error = TRUE)
+  expect_snapshot(tax_certainty(data = tetrapods), error = TRUE)
 })
 
 test_that("tax_certainty errors with unnamed args", {
-  occdf <- tetrapods[1:5, ]
-  expect_snapshot(tax_certainty(occdf, "identified_name"), error = TRUE)
-  expect_snapshot(tax_certainty(taxdf = occdf, "identified_name"), error = TRUE)
-  expect_snapshot(tax_certainty(occdf, "identified_name", NULL), error = TRUE)
+  data <- tetrapods[1:5, ]
+  expect_snapshot(tax_certainty(data, "identified_name"), error = TRUE)
+  expect_snapshot(tax_certainty(data = data, "identified_name"), error = TRUE)
+  expect_snapshot(tax_certainty(data, "identified_name", NULL), error = TRUE)
   expect_snapshot(
-    tax_certainty(occdf, "identified_name", terms = NULL),
+    tax_certainty(data, "identified_name", terms = NULL),
     error = TRUE
   )
 })
 
 test_that("tax_certainty() basic behavior", {
   data("tetrapods")
-  occdf <- tetrapods[1:5, ]
+  data <- tetrapods[1:5, ]
   expect_equal(
-    tax_certainty(taxdf = occdf, name = "identified_name"),
-    cbind(occdf, data.frame(certainty = c(1, 0, 1, 1, 1)))
+    tax_certainty(data = data, name = "identified_name"),
+    cbind(data, data.frame(certainty = c(1, 0, 1, 1, 1)))
   )
 
   # input checks
   expect_snapshot(
-    tax_certainty(taxdf = data.frame(), name = "identified_name"),
+    tax_certainty(data = data.frame(), name = "identified_name"),
     error = TRUE
   )
 })
 
 test_that("arg 'name' works", {
   data("tetrapods")
-  occdf <- tetrapods[1:5, "identified_name", drop = FALSE]
-  colnames(occdf) <- "new_name"
+  data <- tetrapods[1:5, "identified_name", drop = FALSE]
+  colnames(data) <- "new_name"
 
   expect_equal(
-    tax_certainty(taxdf = occdf, name = "new_name"),
-    cbind(occdf, data.frame(certainty = c(1, 0, 1, 1, 1)))
+    tax_certainty(data = data, name = "new_name"),
+    cbind(data, data.frame(certainty = c(1, 0, 1, 1, 1)))
   )
 
   # input checks
   expect_snapshot(
-    tax_certainty(taxdf = occdf, name = "foo"),
+    tax_certainty(data = data, name = "foo"),
     error = TRUE
   )
   expect_snapshot(
-    tax_certainty(taxdf = occdf, name = NULL),
+    tax_certainty(data = data, name = NULL),
     error = TRUE
   )
 
   # TODO: this should error, docs say this should be a column name, not a column index
   # expect_snapshot(
-  #   tax_certainty(taxdf = occdf, name = 1),
+  #   tax_certainty(data = data, name = 1),
   #   error = TRUE
   # )
 })
 
 test_that("arg 'terms' works", {
   data("tetrapods")
-  occdf <- tetrapods[1:5, "identified_name", drop = FALSE]
+  data <- tetrapods[1:5, "identified_name", drop = FALSE]
 
   # "Broiliellus n. sp. arroyoensis" and "n. gen. Ophiodeirus n. sp. casei"
   # now become uncertain
   expect_equal(
     tax_certainty(
-      taxdf = occdf,
+      data = data,
       name = "identified_name",
       terms = list(
         species = "Broiliellus n. sp. arroyoensis",
         genus = "Ophiodeirus"
       )
     ),
-    cbind(occdf, data.frame(certainty = c(1, 0, 1, 0, 0)))
+    cbind(data, data.frame(certainty = c(1, 0, 1, 0, 0)))
   )
 
   # input checks
   expect_snapshot(
-    tax_certainty(taxdf = occdf, name = "identified_name", terms = 1),
+    tax_certainty(data = data, name = "identified_name", terms = 1),
     error = TRUE
   )
 
   # TODO: should error
   # expect_snapshot(
-  #   tax_certainty(taxdf = occdf, name = "identified_name", terms = list(1)),
+  #   tax_certainty(data = data, name = "identified_name", terms = list(1)),
   #   error = TRUE
   # )
 
   # TODO: should error
   # expect_snapshot(
-  #   tax_certainty(taxdf = occdf, name = "identified_name", terms = list(a = 1)),
+  #   tax_certainty(data = data, name = "identified_name", terms = list(a = 1)),
   #   error = TRUE
   # )
 })
 
 test_that("arg 'certainty' works", {
   data("tetrapods")
-  occdf <- tetrapods[1:5, ]
+  data <- tetrapods[1:5, ]
 
   expect_equal(
     tax_certainty(
-      taxdf = occdf,
+      data = data,
       name = "identified_name",
       certainty = c("A", "B")
     ),
-    cbind(occdf, data.frame(certainty = c("A", "B", "A", "A", "A")))
+    cbind(data, data.frame(certainty = c("A", "B", "A", "A", "A")))
   )
 
   # check mixing character and numeric
   expect_equal(
     tax_certainty(
-      taxdf = occdf,
+      data = data,
       name = "identified_name",
       certainty = c("A", 0)
     ),
-    cbind(occdf, data.frame(certainty = c("A", "0", "A", "A", "A")))
+    cbind(data, data.frame(certainty = c("A", "0", "A", "A", "A")))
   )
 
   # input checks
@@ -124,39 +124,39 @@ test_that("arg 'certainty' works", {
   # certainty should be coded."
   #
   # expect_snapshot(
-  #   tax_certainty(taxdf = occdf, name = "identified_name", certainty = "A"),
+  #   tax_certainty(data = data, name = "identified_name", certainty = "A"),
   #   error = TRUE
   # )
   # expect_snapshot(
-  #   tax_certainty(taxdf = occdf, name = "identified_name", certainty = c("A", "B", "C")),
+  #   tax_certainty(data = data, name = "identified_name", certainty = c("A", "B", "C")),
   #   error = TRUE
   # )
 
   # TODO: should error, this doesn't return the column "certainty"
   # expect_snapshot(
-  #   tax_certainty(taxdf = occdf, name = "identified_name", certainty = NULL),
+  #   tax_certainty(data = data, name = "identified_name", certainty = NULL),
   #   error = TRUE
   # )
 
   # TODO: should error, this returns 1 everywhere
   # expect_snapshot(
-  #   tax_certainty(taxdf = occdf, name = "identified_name", certainty = c(1, 1)),
+  #   tax_certainty(data = data, name = "identified_name", certainty = c(1, 1)),
   #   error = TRUE
   # )
 })
 
 test_that("arg 'append' works", {
   data("tetrapods")
-  occdf <- tetrapods[1:5, c("identified_name", "life_habit")]
+  data <- tetrapods[1:5, c("identified_name", "life_habit")]
 
   expect_equal(
     tax_certainty(
-      taxdf = occdf,
+      data = data,
       name = "identified_name",
       append = FALSE
     ),
     cbind(
-      occdf[, "identified_name", drop = FALSE],
+      data[, "identified_name", drop = FALSE],
       data.frame(certainty = c(1, 0, 1, 1, 1))
     )
   )
@@ -164,11 +164,11 @@ test_that("arg 'append' works", {
   # input checks
 
   expect_snapshot(
-    tax_certainty(taxdf = occdf, name = "identified_name", append = 1),
+    tax_certainty(data = data, name = "identified_name", append = 1),
     error = TRUE
   )
   expect_snapshot(
-    tax_certainty(taxdf = occdf, name = "identified_name", append = NA),
+    tax_certainty(data = data, name = "identified_name", append = NA),
     error = TRUE
   )
 })

--- a/tests/testthat/test-tax_check.R
+++ b/tests/testthat/test-tax_check.R
@@ -48,7 +48,7 @@ test_that("piping and not piping the first argument give the same result", {
 test_that("tax_check errors with unnamed args", {
   dat <- data.frame(genus = c("Automaton", "Joebloggsia"))
   expect_snapshot(tax_check(dat, "genus"), error = TRUE)
-  expect_snapshot(tax_check(taxdf = dat, "genus"), error = TRUE)
+  expect_snapshot(tax_check(data = dat, "genus"), error = TRUE)
   expect_snapshot(tax_check(dat, "genus", NULL), error = TRUE)
   expect_snapshot(tax_check(dat, "genus", group = NULL), error = TRUE)
 })

--- a/tests/testthat/test-tax_expand_lat.R
+++ b/tests/testthat/test-tax_expand_lat.R
@@ -9,7 +9,7 @@ test_that("basic behavior works", {
     max = seq(from = 50, to = -30, by = -10)
   )
 
-  taxdf <- data.frame(
+  data <- data.frame(
     name = c("A", "B", "C"),
     max_lat = c(20, 50, -10),
     min_lat = c(-10, 20, -40)
@@ -17,7 +17,7 @@ test_that("basic behavior works", {
 
   # Example: "B" has min_lat = 20 and max_lat = 50 so it fits in bins 1, 2, and 3
   expect_equal(
-    tax_expand_lat(taxdf = taxdf, bins = bins),
+    tax_expand_lat(data = data, bins = bins),
     data.frame(
       name = rep(c("B", "A", "C"), each = 3),
       max_lat = rep(c(50, 20, -10), each = 3),
@@ -30,22 +30,22 @@ test_that("basic behavior works", {
   )
 
   # input checks
-  expect_snapshot(tax_expand_lat(taxdf = 5), error = TRUE)
-  expect_snapshot(tax_expand_lat(taxdf), error = TRUE)
-  expect_snapshot(tax_expand_lat(taxdf, bins = 1), error = TRUE)
+  expect_snapshot(tax_expand_lat(data = 5), error = TRUE)
+  expect_snapshot(tax_expand_lat(data), error = TRUE)
+  expect_snapshot(tax_expand_lat(data, bins = 1), error = TRUE)
   expect_snapshot(
-    tax_expand_lat(taxdf, bins = bins, max_lat = "lat"),
+    tax_expand_lat(data, bins = bins, max_lat = "lat"),
     error = TRUE
   )
   expect_snapshot(
-    tax_expand_lat(taxdf, bins = bins, min_lat = "lat"),
+    tax_expand_lat(data, bins = bins, min_lat = "lat"),
     error = TRUE
   )
 
   # min-max of latitude must be between -90 and 90
   expect_snapshot(
     tax_expand_lat(
-      taxdf = data.frame(
+      data = data.frame(
         name = c("A", "B", "C"),
         max_lat = c(92, 20, -10),
         min_lat = c(20, -40, -60)
@@ -57,7 +57,7 @@ test_that("basic behavior works", {
 
   expect_snapshot(
     tax_expand_lat(
-      taxdf = data.frame(
+      data = data.frame(
         name = c("A", "B", "C"),
         max_lat = c(60, 20, -10),
         min_lat = c(-92, -40, -60)
@@ -70,7 +70,7 @@ test_that("basic behavior works", {
   # same with many values outside the range
   expect_snapshot(
     tax_expand_lat(
-      taxdf = data.frame(
+      data = data.frame(
         name = "a",
         max_lat = 91:100,
         min_lat = 1
@@ -81,7 +81,7 @@ test_that("basic behavior works", {
   )
   expect_snapshot(
     tax_expand_lat(
-      taxdf = data.frame(
+      data = data.frame(
         name = "a",
         max_lat = 1,
         min_lat = 91:100
@@ -94,7 +94,7 @@ test_that("basic behavior works", {
   # wrong column types
   expect_snapshot(
     tax_expand_lat(
-      taxdf = data.frame(
+      data = data.frame(
         name = c("A", "B", "C"),
         max_lat = c("60", "20", "-10"),
         min_lat = c(-90, -40, -60)
@@ -106,7 +106,7 @@ test_that("basic behavior works", {
 
   expect_snapshot(
     tax_expand_lat(
-      taxdf = data.frame(
+      data = data.frame(
         name = c("A", "B", "C"),
         max_lat = c(60, 20, -10),
         min_lat = c("20", -40, -60)
@@ -119,7 +119,7 @@ test_that("basic behavior works", {
   # can't have min latitude > max latitude
   expect_snapshot(
     tax_expand_lat(
-      taxdf = data.frame(
+      data = data.frame(
         name = c("A", "B", "C"),
         max_lat = c(60, 20, -10),
         min_lat = c(72, -40, -60)
@@ -131,7 +131,7 @@ test_that("basic behavior works", {
   # same with many cases
   expect_snapshot(
     tax_expand_lat(
-      taxdf = data.frame(
+      data = data.frame(
         name = "a",
         max_lat = c(90, 1:10),
         min_lat = c(72, 21:30)
@@ -144,7 +144,7 @@ test_that("basic behavior works", {
   # must have unique rows
   expect_snapshot(
     tax_expand_lat(
-      taxdf = data.frame(
+      data = data.frame(
         name = c("A", "A", "C"),
         max_lat = c(60, 60, -10),
         min_lat = c(20, 20, -60)
@@ -156,21 +156,21 @@ test_that("basic behavior works", {
 
   # TODO: should we error on this? Doesn't make sense to have the same name with
   # different lat/lon
-  # taxdf <- data.frame(
+  # data <- data.frame(
   #   name = c("A", "A", "C"),
   #   max_lat = c(60, 50, -10),
   #   min_lat = c(20, 40, -60)
   # )
-  # expect_snapshot(tax_expand_lat(taxdf = taxdf, bins = bins), error = TRUE)
+  # expect_snapshot(tax_expand_lat(data = data, bins = bins), error = TRUE)
 
   # missing column
-  taxdf <- data.frame(
+  data <- data.frame(
     name = c("A", "B", "C"),
     max_lat = c(60, 20, -10),
     min_lat = c(20, -40, -60)
   )
   bins <- bins[, -1]
-  expect_snapshot(tax_expand_lat(taxdf = taxdf, bins = bins), error = TRUE)
+  expect_snapshot(tax_expand_lat(data = data, bins = bins), error = TRUE)
 })
 
 test_that("piping and not piping the first argument give the same result", {
@@ -181,15 +181,15 @@ test_that("piping and not piping the first argument give the same result", {
     max = seq(from = 50, to = -30, by = -10)
   )
 
-  taxdf <- data.frame(
+  data <- data.frame(
     name = c("A", "B", "C"),
     max_lat = c(20, 50, -10),
     min_lat = c(-10, 20, -40)
   )
 
   expect_equal(
-    taxdf |> tax_expand_lat(bins = bins),
-    tax_expand_lat(taxdf, bins = bins)
+    data |> tax_expand_lat(bins = bins),
+    tax_expand_lat(data, bins = bins)
   )
 })
 
@@ -201,16 +201,16 @@ test_that("tax_expand_lat errors with unnamed args", {
     max = seq(from = 50, to = -30, by = -10)
   )
 
-  taxdf <- data.frame(
+  data <- data.frame(
     name = c("A", "B", "C"),
     max_lat = c(20, 50, -10),
     min_lat = c(-10, 20, -40)
   )
 
-  expect_snapshot(tax_expand_lat(taxdf, bins), error = TRUE)
-  expect_snapshot(tax_expand_lat(taxdf, bins, "max_lat"), error = TRUE)
+  expect_snapshot(tax_expand_lat(data, bins), error = TRUE)
+  expect_snapshot(tax_expand_lat(data, bins, "max_lat"), error = TRUE)
   expect_snapshot(
-    tax_expand_lat(taxdf, bins, max_lat = "max_lat"),
+    tax_expand_lat(data, bins, max_lat = "max_lat"),
     error = TRUE
   )
 })
@@ -223,18 +223,18 @@ test_that("args 'min_lat' and 'max_lat' work", {
     max = seq(from = 50, to = -30, by = -10)
   )
 
-  taxdf <- data.frame(
+  data <- data.frame(
     name = c("A", "B", "C"),
     foo_max = c(20, 50, -10),
     foo_min = c(-10, 20, -40)
   )
 
-  expect_snapshot(tax_expand_lat(taxdf = taxdf, bins = bins), error = TRUE)
+  expect_snapshot(tax_expand_lat(data = data, bins = bins), error = TRUE)
 
   # Example: "B" has min_lat = 20 and max_lat = 50 so it fits in bins 1, 2, and 3
   expect_equal(
     tax_expand_lat(
-      taxdf = taxdf,
+      data = data,
       bins = bins,
       max_lat = "foo_max",
       min_lat = "foo_min"
@@ -252,47 +252,47 @@ test_that("args 'min_lat' and 'max_lat' work", {
 
   # input checks
   expect_snapshot(
-    tax_expand_lat(taxdf = taxdf, bins = bins, max_lat = "nonexistent"),
+    tax_expand_lat(data = data, bins = bins, max_lat = "nonexistent"),
     error = TRUE
   )
   expect_snapshot(
-    tax_expand_lat(taxdf = taxdf, bins = bins, max_lat = NULL),
+    tax_expand_lat(data = data, bins = bins, max_lat = NULL),
     error = TRUE
   )
   expect_snapshot(
-    tax_expand_lat(taxdf = taxdf, bins = bins, max_lat = character(0)),
+    tax_expand_lat(data = data, bins = bins, max_lat = character(0)),
     error = TRUE
   )
   expect_snapshot(
-    tax_expand_lat(taxdf = taxdf, bins = bins, max_lat = NA),
+    tax_expand_lat(data = data, bins = bins, max_lat = NA),
     error = TRUE
   )
   expect_snapshot(
-    tax_expand_lat(taxdf = taxdf, bins = bins, max_lat = c("a", "b")),
+    tax_expand_lat(data = data, bins = bins, max_lat = c("a", "b")),
     error = TRUE
   )
 
   # So that we don't need to specify the max_lat argument in the calls below
-  colnames(taxdf)[2] <- "max_lat"
+  colnames(data)[2] <- "max_lat"
 
   expect_snapshot(
-    tax_expand_lat(taxdf = taxdf, bins = bins, min_lat = "nonexistent"),
+    tax_expand_lat(data = data, bins = bins, min_lat = "nonexistent"),
     error = TRUE
   )
   expect_snapshot(
-    tax_expand_lat(taxdf = taxdf, bins = bins, min_lat = NULL),
+    tax_expand_lat(data = data, bins = bins, min_lat = NULL),
     error = TRUE
   )
   expect_snapshot(
-    tax_expand_lat(taxdf = taxdf, bins = bins, min_lat = character(0)),
+    tax_expand_lat(data = data, bins = bins, min_lat = character(0)),
     error = TRUE
   )
   expect_snapshot(
-    tax_expand_lat(taxdf = taxdf, bins = bins, min_lat = NA),
+    tax_expand_lat(data = data, bins = bins, min_lat = NA),
     error = TRUE
   )
   expect_snapshot(
-    tax_expand_lat(taxdf = taxdf, bins = bins, min_lat = c("a", "b")),
+    tax_expand_lat(data = data, bins = bins, min_lat = c("a", "b")),
     error = TRUE
   )
 })

--- a/tests/testthat/test-tax_expand_time.R
+++ b/tests/testthat/test-tax_expand_time.R
@@ -1,11 +1,11 @@
 test_that("basic behaviour works", {
-  taxdf <- data.frame(
+  data <- data.frame(
     name = c("A", "B"),
     max_ma = c(150, 30),
     min_ma = c(110, 0)
   )
 
-  out <- tax_expand_time(taxdf)
+  out <- tax_expand_time(data)
   # fmt: skip
   expect_equal(
     out[, c("name", "interval_name")],
@@ -42,58 +42,58 @@ test_that("basic behaviour works", {
 })
 
 test_that("piping and not piping the first argument give the same result", {
-  taxdf <- data.frame(
+  data <- data.frame(
     name = c("A", "B"),
     max_ma = c(150, 30),
     min_ma = c(110, 0)
   )
 
   expect_equal(
-    taxdf |> tax_expand_time(),
-    tax_expand_time(taxdf)
+    data |> tax_expand_time(),
+    tax_expand_time(data)
   )
 })
 
 test_that("tax_expand_time errors with unnamed args", {
-  taxdf <- data.frame(
+  data <- data.frame(
     name = c("A", "B"),
     max_ma = c(150, 30),
     min_ma = c(110, 0)
   )
-  expect_snapshot(tax_expand_time(taxdf, "max_ma"), error = TRUE)
-  expect_snapshot(tax_expand_time(taxdf, "max_ma"), error = TRUE)
-  expect_snapshot(tax_expand_time(taxdf, "max_ma", "min_ma"), error = TRUE)
+  expect_snapshot(tax_expand_time(data, "max_ma"), error = TRUE)
+  expect_snapshot(tax_expand_time(data, "max_ma"), error = TRUE)
+  expect_snapshot(tax_expand_time(data, "max_ma", "min_ma"), error = TRUE)
   expect_snapshot(
-    tax_expand_time(taxdf, "max_ma", min_ma = "min_ma"),
+    tax_expand_time(data, "max_ma", min_ma = "min_ma"),
     error = TRUE
   )
 })
 
 test_that("rows must be unique", {
-  taxdf <- data.frame(
+  data <- data.frame(
     name = c("A", "A", "C"),
     max_ma = c(150, 150, 30),
     min_ma = c(110, 110, 0)
   )
-  expect_snapshot(tax_expand_time(taxdf), error = TRUE)
+  expect_snapshot(tax_expand_time(data), error = TRUE)
 })
 
 test_that("ages must be positive", {
-  taxdf <- data.frame(
+  data <- data.frame(
     name = c("A", "A", "C"),
     max_ma = c(150, 150, 30),
     min_ma = c(110, 110, -20)
   )
-  expect_snapshot(tax_expand_time(taxdf), error = TRUE)
+  expect_snapshot(tax_expand_time(data), error = TRUE)
 })
 
 test_that("max ages must be larger than or equal to min ages", {
-  taxdf <- data.frame(
+  data <- data.frame(
     name = c("A", "B", "C"),
     max_ma = c(150, 150, 30),
     min_ma = c(110, 110, 40)
   )
-  expect_snapshot(tax_expand_time(taxdf), error = TRUE)
+  expect_snapshot(tax_expand_time(data), error = TRUE)
 })
 
 test_that("arg 'bins' works", {
@@ -103,7 +103,7 @@ test_that("arg 'bins' works", {
     min_ma = c(120, 80, 40, 0)
   )
 
-  taxdf <- data.frame(
+  data <- data.frame(
     name = c("A", "B"),
     max_ma = c(150, 30),
     min_ma = c(110, 0)
@@ -117,9 +117,9 @@ test_that("arg 'bins' works", {
   # "C" spans 0-30 Ma, so it falls in bin 4 (0-40) only.
   # `ext` flags the bin in which a taxon goes extinct (its LAD), and `orig`
   # the bin in which it originates (its FAD). Note that `bins` also carries
-  # "max_ma"/"min_ma" columns, which are appended after those of `taxdf`.
+  # "max_ma"/"min_ma" columns, which are appended after those of `data`.
   expect_equal(
-    tax_expand_time(taxdf, bins = bins),
+    tax_expand_time(data, bins = bins),
     # jarl-ignore duplicated_arguments: this will be fixed later
     data.frame(
       name = c("A", "A", "B"),
@@ -135,9 +135,9 @@ test_that("arg 'bins' works", {
   )
 
   # input checks
-  expect_snapshot(tax_expand_time(taxdf, bins = data.frame()), error = TRUE)
-  expect_snapshot(tax_expand_time(taxdf, bins = 1), error = TRUE)
-  expect_snapshot(tax_expand_time(taxdf, bins = NA), error = TRUE)
+  expect_snapshot(tax_expand_time(data, bins = data.frame()), error = TRUE)
+  expect_snapshot(tax_expand_time(data, bins = 1), error = TRUE)
+  expect_snapshot(tax_expand_time(data, bins = NA), error = TRUE)
 })
 
 test_that("args 'max_ma' and 'min_ma' work", {
@@ -147,7 +147,7 @@ test_that("args 'max_ma' and 'min_ma' work", {
     min_ma = c(120, 80, 40, 0)
   )
 
-  taxdf <- data.frame(
+  data <- data.frame(
     name = c("A", "B"),
     fad = c(150, 30),
     lad = c(110, 0)
@@ -155,7 +155,7 @@ test_that("args 'max_ma' and 'min_ma' work", {
 
   # pointing to the renamed columns reproduces the basic behavior
   expect_equal(
-    tax_expand_time(taxdf, bins = bins, max_ma = "fad", min_ma = "lad"),
+    tax_expand_time(data, bins = bins, max_ma = "fad", min_ma = "lad"),
     data.frame(
       name = c("A", "A", "B"),
       fad = c(150, 150, 30),
@@ -169,61 +169,61 @@ test_that("args 'max_ma' and 'min_ma' work", {
   )
 
   # the default "max_ma"/"min_ma" column names are absent
-  expect_snapshot(tax_expand_time(taxdf, bins = bins), error = TRUE)
+  expect_snapshot(tax_expand_time(data, bins = bins), error = TRUE)
 
   # input checks on `max_ma`
   expect_snapshot(
-    tax_expand_time(taxdf, bins = bins, max_ma = "nonexistent", min_ma = "lad"),
+    tax_expand_time(data, bins = bins, max_ma = "nonexistent", min_ma = "lad"),
     error = TRUE
   )
   expect_snapshot(
-    tax_expand_time(taxdf, bins = bins, max_ma = NULL, min_ma = "lad"),
+    tax_expand_time(data, bins = bins, max_ma = NULL, min_ma = "lad"),
     error = TRUE
   )
   expect_snapshot(
-    tax_expand_time(taxdf, bins = bins, max_ma = character(0), min_ma = "lad"),
+    tax_expand_time(data, bins = bins, max_ma = character(0), min_ma = "lad"),
     error = TRUE
   )
   expect_snapshot(
-    tax_expand_time(taxdf, bins = bins, max_ma = NA, min_ma = "lad"),
+    tax_expand_time(data, bins = bins, max_ma = NA, min_ma = "lad"),
     error = TRUE
   )
   expect_snapshot(
-    tax_expand_time(taxdf, bins = bins, max_ma = c("a", "b"), min_ma = "lad"),
+    tax_expand_time(data, bins = bins, max_ma = c("a", "b"), min_ma = "lad"),
     error = TRUE
   )
 
   # input checks on `min_ma`
   expect_snapshot(
-    tax_expand_time(taxdf, bins = bins, max_ma = "fad", min_ma = "nonexistent"),
+    tax_expand_time(data, bins = bins, max_ma = "fad", min_ma = "nonexistent"),
     error = TRUE
   )
   expect_snapshot(
-    tax_expand_time(taxdf, bins = bins, max_ma = "fad", min_ma = NULL),
+    tax_expand_time(data, bins = bins, max_ma = "fad", min_ma = NULL),
     error = TRUE
   )
   expect_snapshot(
-    tax_expand_time(taxdf, bins = bins, max_ma = "fad", min_ma = character(0)),
+    tax_expand_time(data, bins = bins, max_ma = "fad", min_ma = character(0)),
     error = TRUE
   )
   expect_snapshot(
-    tax_expand_time(taxdf, bins = bins, max_ma = "fad", min_ma = NA),
+    tax_expand_time(data, bins = bins, max_ma = "fad", min_ma = NA),
     error = TRUE
   )
   expect_snapshot(
-    tax_expand_time(taxdf, bins = bins, max_ma = "fad", min_ma = c("a", "b")),
+    tax_expand_time(data, bins = bins, max_ma = "fad", min_ma = c("a", "b")),
     error = TRUE
   )
 })
 
 test_that("arg 'scale' works", {
-  taxdf <- data.frame(
+  data <- data.frame(
     name = c("A", "B"),
     max_ma = c(150, 30),
     min_ma = c(110, 0)
   )
 
-  out <- tax_expand_time(taxdf, scale = "GTS2012")
+  out <- tax_expand_time(data, scale = "GTS2012")
 
   # fmt: skip
   expect_equal(
@@ -249,22 +249,22 @@ test_that("arg 'scale' works", {
   )
 
   # input checks
-  expect_snapshot(tax_expand_time(taxdf, scale = "foo"), error = TRUE)
-  expect_snapshot(tax_expand_time(taxdf, scale = character(0)), error = TRUE)
-  expect_snapshot(tax_expand_time(taxdf, scale = NULL), error = TRUE)
-  expect_snapshot(tax_expand_time(taxdf, scale = 1), error = TRUE)
-  expect_snapshot(tax_expand_time(taxdf, scale = NA), error = TRUE)
+  expect_snapshot(tax_expand_time(data, scale = "foo"), error = TRUE)
+  expect_snapshot(tax_expand_time(data, scale = character(0)), error = TRUE)
+  expect_snapshot(tax_expand_time(data, scale = NULL), error = TRUE)
+  expect_snapshot(tax_expand_time(data, scale = 1), error = TRUE)
+  expect_snapshot(tax_expand_time(data, scale = NA), error = TRUE)
 })
 
 test_that("arg 'rank' works", {
-  taxdf <- data.frame(
+  data <- data.frame(
     name = c("A", "B"),
     max_ma = c(150, 30),
     min_ma = c(110, 0)
   )
 
   # epoch -------------------------------
-  epoch <- tax_expand_time(taxdf, rank = "epoch")
+  epoch <- tax_expand_time(data, rank = "epoch")
   # fmt: skip
   expect_equal(
     epoch[, c("name", "interval_name", "rank")],
@@ -287,7 +287,7 @@ test_that("arg 'rank' works", {
   )
 
   # period -------------------------------
-  period <- tax_expand_time(taxdf, rank = "period")
+  period <- tax_expand_time(data, rank = "period")
   # fmt: skip
   expect_equal(
     period[, c("name", "interval_name", "rank")],
@@ -307,7 +307,7 @@ test_that("arg 'rank' works", {
   )
 
   # era -------------------------------
-  era <- tax_expand_time(taxdf, rank = "era")
+  era <- tax_expand_time(data, rank = "era")
   expect_equal(
     era[, c("name", "interval_name", "rank")],
     data.frame(
@@ -326,7 +326,7 @@ test_that("arg 'rank' works", {
   )
 
   # eon -------------------------------
-  eon <- tax_expand_time(taxdf, rank = "eon")
+  eon <- tax_expand_time(data, rank = "eon")
   expect_equal(
     eon[, c("name", "interval_name", "rank")],
     data.frame(name = c("A", "B"), interval_name = "Phanerozoic", rank = "eon")
@@ -342,37 +342,37 @@ test_that("arg 'rank' works", {
 
   # TODO: rank = NULL should work if we provide bins
   # https://github.com/palaeoverse/palaeoverse/pull/247/changes#r3842362378
-  # taxdf <- data.frame(
+  # data <- data.frame(
   #   name = c("A", "B", "C"),
   #   max_ma = c(150, 60, 30),
   #   min_ma = c(110, 20, 0)
   # )
   # bins <- time_bins(scale = "GTS2012", rank = "stage")
   # expect_equal(
-  #   tax_expand_time(taxdf, bins = bins),
-  #   tax_expand_time(taxdf, bins = bins, rank = NULL)
+  #   tax_expand_time(data, bins = bins),
+  #   tax_expand_time(data, bins = bins, rank = NULL)
   # )
 
   # input checks
   expect_snapshot(
-    tax_expand_time(taxdf, rank = c("eon", "period")),
+    tax_expand_time(data, rank = c("eon", "period")),
     error = TRUE
   )
-  expect_snapshot(tax_expand_time(taxdf, rank = "foo"), error = TRUE)
-  expect_snapshot(tax_expand_time(taxdf, rank = character(0)), error = TRUE)
-  expect_snapshot(tax_expand_time(taxdf, rank = NULL), error = TRUE)
-  expect_snapshot(tax_expand_time(taxdf, rank = 1), error = TRUE)
-  expect_snapshot(tax_expand_time(taxdf, rank = NA), error = TRUE)
+  expect_snapshot(tax_expand_time(data, rank = "foo"), error = TRUE)
+  expect_snapshot(tax_expand_time(data, rank = character(0)), error = TRUE)
+  expect_snapshot(tax_expand_time(data, rank = NULL), error = TRUE)
+  expect_snapshot(tax_expand_time(data, rank = 1), error = TRUE)
+  expect_snapshot(tax_expand_time(data, rank = NA), error = TRUE)
 })
 
 test_that("arg 'ext_orig' works", {
-  taxdf <- data.frame(
+  data <- data.frame(
     name = c("A", "B"),
     max_ma = c(150, 30),
     min_ma = c(110, 0)
   )
 
-  out <- tax_expand_time(taxdf, ext_orig = FALSE)
+  out <- tax_expand_time(data, ext_orig = FALSE)
 
   # fmt: skip
   expect_named(
@@ -384,9 +384,9 @@ test_that("arg 'ext_orig' works", {
   )
 
   # input checks
-  expect_snapshot(tax_expand_time(taxdf, ext_orig = "foo"), error = TRUE)
-  expect_snapshot(tax_expand_time(taxdf, ext_orig = logical(0)), error = TRUE)
-  expect_snapshot(tax_expand_time(taxdf, ext_orig = NULL), error = TRUE)
-  expect_snapshot(tax_expand_time(taxdf, ext_orig = 1), error = TRUE)
-  expect_snapshot(tax_expand_time(taxdf, ext_orig = NA), error = TRUE)
+  expect_snapshot(tax_expand_time(data, ext_orig = "foo"), error = TRUE)
+  expect_snapshot(tax_expand_time(data, ext_orig = logical(0)), error = TRUE)
+  expect_snapshot(tax_expand_time(data, ext_orig = NULL), error = TRUE)
+  expect_snapshot(tax_expand_time(data, ext_orig = 1), error = TRUE)
+  expect_snapshot(tax_expand_time(data, ext_orig = NA), error = TRUE)
 })

--- a/tests/testthat/test-tax_range_space.R
+++ b/tests/testthat/test-tax_range_space.R
@@ -1,10 +1,10 @@
 test_that("tax_range_space() works", {
-  occdf <- data.frame(
+  data <- data.frame(
     genus = c("A", "A", "A", "A", "B", "B", "C"),
     lng = c(0, 10, 10, 0, 30, 40, 100),
     lat = c(0, 0, 10, 10, 45, 50, -10)
   )
-  out <- tax_range_space(occdf)
+  out <- tax_range_space(data)
 
   expect_equal(
     out,
@@ -21,47 +21,47 @@ test_that("tax_range_space() works", {
   # jarl-ignore expect_length: would be less readable to use expect_length in this case
   expect_equal(
     nrow(out),
-    length(unique(occdf$genus))
+    length(unique(data$genus))
   )
 
   # input checks
-  expect_snapshot(tax_range_space(occdf = data.frame()), error = TRUE)
-  expect_snapshot(tax_range_space(occdf = NA), error = TRUE)
-  expect_snapshot(tax_range_space(occdf = "a"), error = TRUE)
+  expect_snapshot(tax_range_space(data = data.frame()), error = TRUE)
+  expect_snapshot(tax_range_space(data = NA), error = TRUE)
+  expect_snapshot(tax_range_space(data = "a"), error = TRUE)
 })
 
 test_that("piping and not piping the first argument give the same result", {
-  occdf <- data.frame(
+  data <- data.frame(
     genus = c("A", "A", "A", "A", "B", "B", "C"),
     lng = c(0, 10, 10, 0, 30, 40, 100),
     lat = c(0, 0, 10, 10, 45, 50, -10)
   )
   expect_equal(
-    occdf |> tax_range_space(name = "genus"),
-    tax_range_space(occdf, name = "genus")
+    data |> tax_range_space(name = "genus"),
+    tax_range_space(data, name = "genus")
   )
 })
 
 test_that("tax_range_space errors with unnamed args", {
-  occdf <- data.frame(
+  data <- data.frame(
     genus = c("A", "A", "B"),
     lng = c(0, 10, 30),
     lat = c(0, 0, 45)
   )
-  expect_snapshot(tax_range_space(occdf, "genus"), error = TRUE)
-  expect_snapshot(tax_range_space(occdf, "genus", "lng"), error = TRUE)
-  expect_snapshot(tax_range_space(occdf, "genus", lng = "lng"), error = TRUE)
+  expect_snapshot(tax_range_space(data, "genus"), error = TRUE)
+  expect_snapshot(tax_range_space(data, "genus", "lng"), error = TRUE)
+  expect_snapshot(tax_range_space(data, "genus", lng = "lng"), error = TRUE)
 })
 
 test_that("argument 'name' works", {
-  occdf <- data.frame(
+  data <- data.frame(
     species = c("A", "A", "A", "A", "B", "B", "C"),
     lng = c(0, 10, 10, 0, 30, 40, 100),
     lat = c(0, 0, 10, 10, 45, 50, -10)
   )
 
   expect_equal(
-    tax_range_space(occdf, name = "species"),
+    tax_range_space(data, name = "species"),
     data.frame(
       taxon = c("A", "B", "C"),
       taxon_id = 1:3,
@@ -73,26 +73,26 @@ test_that("argument 'name' works", {
 
   # input checks
   expect_snapshot(
-    tax_range_space(occdf = occdf, name = "nonexistent"),
+    tax_range_space(data = data, name = "nonexistent"),
     error = TRUE
   )
-  nadf <- occdf
+  nadf <- data
   nadf$genus[1] <- NA
   expect_snapshot(
-    tax_range_space(occdf = nadf, name = "genus"),
+    tax_range_space(data = nadf, name = "genus"),
     error = TRUE
   )
 })
 
 test_that("argument 'lng' works", {
-  occdf <- data.frame(
+  data <- data.frame(
     genus = c("A", "A", "A", "A", "B", "B", "C"),
     p_lng = c(0, 10, 10, 0, 30, 40, 100),
     lat = c(0, 0, 10, 10, 45, 50, -10)
   )
 
   expect_equal(
-    tax_range_space(occdf, lng = "p_lng"),
+    tax_range_space(data, lng = "p_lng"),
     data.frame(
       taxon = c("A", "B", "C"),
       taxon_id = 1:3,
@@ -104,7 +104,7 @@ test_that("argument 'lng' works", {
 
   # input checks
   expect_snapshot(
-    tax_range_space(occdf, lng = "nonexistent"),
+    tax_range_space(data, lng = "nonexistent"),
     error = TRUE
   )
   # the "lng" column must be numeric
@@ -122,14 +122,14 @@ test_that("argument 'lng' works", {
 })
 
 test_that("argument 'lat' works", {
-  occdf <- data.frame(
+  data <- data.frame(
     genus = c("A", "A", "A", "A", "B", "B", "C"),
     lng = c(0, 10, 10, 0, 30, 40, 100),
     p_lat = c(0, 0, 10, 10, 45, 50, -10)
   )
 
   expect_equal(
-    tax_range_space(occdf, lat = "p_lat"),
+    tax_range_space(data, lat = "p_lat"),
     data.frame(
       taxon = c("A", "B", "C"),
       taxon_id = 1:3,
@@ -141,7 +141,7 @@ test_that("argument 'lat' works", {
 
   # input checks
   expect_snapshot(
-    tax_range_space(occdf, lat = "nonexistent"),
+    tax_range_space(data, lat = "nonexistent"),
     error = TRUE
   )
   # the "lat" column must be numeric
@@ -159,14 +159,14 @@ test_that("argument 'lat' works", {
 })
 
 test_that("argument 'method' works", {
-  occdf <- data.frame(
+  data <- data.frame(
     genus = c("A", "A", "A", "A", "B", "B", "C"),
     lng = c(0, 10, 10, 0, 30, 40, 100),
     lat = c(0, 0, 10, 10, 45, 50, -10)
   )
 
   expect_equal(
-    tax_range_space(occdf, method = "lat"),
+    tax_range_space(data, method = "lat"),
     data.frame(
       taxon = c("A", "B", "C"),
       taxon_id = 1:3,
@@ -177,7 +177,7 @@ test_that("argument 'method' works", {
   )
 
   expect_equal(
-    tax_range_space(occdf, method = "con"),
+    tax_range_space(data, method = "con"),
     data.frame(
       taxon = c("A", "B", "C"),
       taxon_id = 1:3,
@@ -187,7 +187,7 @@ test_that("argument 'method' works", {
   )
 
   expect_equal(
-    tax_range_space(occdf, method = "gcd"),
+    tax_range_space(data, method = "gcd"),
     data.frame(
       taxon = c("A", "B", "C"),
       taxon_id = 1:3,
@@ -197,7 +197,7 @@ test_that("argument 'method' works", {
   )
 
   expect_equal(
-    tax_range_space(occdf, method = "occ"),
+    tax_range_space(data, method = "occ"),
     data.frame(
       taxon = c("A", "B", "C"),
       taxon_id = c(1, 2, 3),
@@ -209,24 +209,24 @@ test_that("argument 'method' works", {
 
   # input checks
   expect_snapshot(
-    tax_range_space(occdf, method = c("gcd", "occ")),
+    tax_range_space(data, method = c("gcd", "occ")),
     error = TRUE
   )
-  expect_snapshot(tax_range_space(occdf, method = "test"), error = TRUE)
-  expect_snapshot(tax_range_space(occdf, method = character(0)), error = TRUE)
-  expect_snapshot(tax_range_space(occdf, method = NA), error = TRUE)
-  expect_snapshot(tax_range_space(occdf, method = 1), error = TRUE)
+  expect_snapshot(tax_range_space(data, method = "test"), error = TRUE)
+  expect_snapshot(tax_range_space(data, method = character(0)), error = TRUE)
+  expect_snapshot(tax_range_space(data, method = NA), error = TRUE)
+  expect_snapshot(tax_range_space(data, method = 1), error = TRUE)
 })
 
 test_that("argument 'spacing' works", {
-  occdf <- data.frame(
+  data <- data.frame(
     genus = c("A", "A", "A", "A", "B", "B", "C"),
     lng = c(0, 10, 10, 0, 30, 40, 100),
     lat = c(0, 0, 10, 10, 45, 50, -10)
   )
 
-  small <- tax_range_space(occdf, method = "occ", spacing = 100)
-  large <- tax_range_space(occdf, method = "occ", spacing = 500)
+  small <- tax_range_space(data, method = "occ", spacing = 100)
+  large <- tax_range_space(data, method = "occ", spacing = 500)
 
   expect_true(unique(large$spacing) > unique(small$spacing))
   expect_length(unique(small$spacing), 1L)
@@ -234,37 +234,37 @@ test_that("argument 'spacing' works", {
   # "spacing" is only relevant for the "occ" method: it is ignored otherwise
   # TODO: should this error ?
   expect_equal(
-    tax_range_space(occdf, method = "lat", spacing = 500),
-    tax_range_space(occdf, method = "lat", spacing = 100)
+    tax_range_space(data, method = "lat", spacing = 500),
+    tax_range_space(data, method = "lat", spacing = 100)
   )
 
   # input checks
   expect_snapshot(
-    tax_range_space(occdf, method = "occ", spacing = "a"),
+    tax_range_space(data, method = "occ", spacing = "a"),
     error = TRUE
   )
   expect_snapshot(
-    tax_range_space(occdf, method = "occ", spacing = numeric(0)),
+    tax_range_space(data, method = "occ", spacing = numeric(0)),
     error = TRUE
   )
   expect_snapshot(
-    tax_range_space(occdf, method = "occ", spacing = NA),
+    tax_range_space(data, method = "occ", spacing = NA),
     error = TRUE
   )
   expect_snapshot(
-    tax_range_space(occdf, method = "occ", spacing = 1:2),
+    tax_range_space(data, method = "occ", spacing = 1:2),
     error = TRUE
   )
 })
 
 test_that("argument 'coords' works", {
-  occdf <- data.frame(
+  data <- data.frame(
     genus = c("A", "A", "A", "A", "B", "B", "C"),
     lng = c(0, 10, 10, 0, 30, 40, 100),
     lat = c(0, 0, 10, 10, 45, 50, -10)
   )
   expect_equal(
-    tax_range_space(occdf, method = "con", coords = TRUE),
+    tax_range_space(data, method = "con", coords = TRUE),
     data.frame(
       taxon = rep(c("A", "B", "C"), c(4L, 2L, 1L)),
       taxon_id = rep(1:3, c(4L, 2L, 1L)),
@@ -277,7 +277,7 @@ test_that("argument 'coords' works", {
   # For the "gcd" method, coords = TRUE returns the coordinates of the two most
   # distant points
   expect_equal(
-    tax_range_space(occdf, method = "gcd", coords = TRUE),
+    tax_range_space(data, method = "gcd", coords = TRUE),
     data.frame(
       taxon = rep(c("A", "B", "C"), each = 2L),
       taxon_id = rep(1:3, each = 2L),
@@ -289,15 +289,15 @@ test_that("argument 'coords' works", {
 
   # input checks
   expect_snapshot(
-    tax_range_space(occdf, method = "gcd", coords = "a"),
+    tax_range_space(data, method = "gcd", coords = "a"),
     error = TRUE
   )
   expect_snapshot(
-    tax_range_space(occdf, method = "gcd", coords = logical(0)),
+    tax_range_space(data, method = "gcd", coords = logical(0)),
     error = TRUE
   )
   expect_snapshot(
-    tax_range_space(occdf, method = "gcd", coords = NA),
+    tax_range_space(data, method = "gcd", coords = NA),
     error = TRUE
   )
 })

--- a/tests/testthat/test-tax_range_strat.R
+++ b/tests/testthat/test-tax_range_strat.R
@@ -1,15 +1,15 @@
 test_that("basic behavior works", {
   # fmt: skip
-  occdf <- data.frame(
+  data <- data.frame(
     genus = c(
-      "Anconastes", "Procolophon", "Procolophon", "Anconastes", "Araeoscelis", "Araeoscelis", 
+      "Anconastes", "Procolophon", "Procolophon", "Anconastes", "Araeoscelis", "Araeoscelis",
       "Edaphosaurus", "Procolophon"
     ),
     bed = c(1, 1, 2, 2, 2, 3, 3, 4),
     certainty = c(1, 1, 0, 1, 0, 1, 1, 1)
   )
   expect_equal(
-    tax_range_strat(occdf),
+    tax_range_strat(data),
     data.frame(
       ID = 1:4,
       taxon = c("Anconastes", "Procolophon", "Araeoscelis", "Edaphosaurus"),
@@ -22,7 +22,7 @@ test_that("basic behavior works", {
 
   # It produces the expected plot
   expect_doppelganger("tax_range_strat() plots", function() {
-    tax_range_strat(occdf)
+    tax_range_strat(data)
   })
 
   # input checks
@@ -34,7 +34,7 @@ test_that("basic behavior works", {
 
 test_that("piping and not piping the first argument give the same result", {
   # fmt: skip
-  occdf <- data.frame(
+  data <- data.frame(
     genus = c(
       "Anconastes", "Procolophon", "Procolophon", "Anconastes", "Araeoscelis", "Araeoscelis",
       "Edaphosaurus", "Procolophon"
@@ -43,27 +43,27 @@ test_that("piping and not piping the first argument give the same result", {
     certainty = c(1, 1, 0, 1, 0, 1, 1, 1)
   )
   expect_equal(
-    occdf |> tax_range_strat(name = "genus"),
-    tax_range_strat(occdf, name = "genus")
+    data |> tax_range_strat(name = "genus"),
+    tax_range_strat(data, name = "genus")
   )
 })
 
 test_that("tax_range_strat errors with unnamed args", {
-  occdf <- data.frame(
+  data <- data.frame(
     genus = c("Anconastes", "Procolophon", "Procolophon"),
     bed = c(1, 1, 2)
   )
-  expect_snapshot(tax_range_strat(occdf, "genus"), error = TRUE)
-  expect_snapshot(tax_range_strat(occdf, "genus"), error = TRUE)
-  expect_snapshot(tax_range_strat(occdf, "genus", "bed"), error = TRUE)
-  expect_snapshot(tax_range_strat(occdf, "genus", level = "bed"), error = TRUE)
+  expect_snapshot(tax_range_strat(data, "genus"), error = TRUE)
+  expect_snapshot(tax_range_strat(data, "genus"), error = TRUE)
+  expect_snapshot(tax_range_strat(data, "genus", "bed"), error = TRUE)
+  expect_snapshot(tax_range_strat(data, "genus", level = "bed"), error = TRUE)
 })
 
 test_that("argument 'name' works", {
   # fmt: skip
-  occdf <- data.frame(
+  data <- data.frame(
     species = c(
-      "Anconastes", "Procolophon", "Procolophon", "Anconastes", "Araeoscelis", "Araeoscelis", 
+      "Anconastes", "Procolophon", "Procolophon", "Anconastes", "Araeoscelis", "Araeoscelis",
       "Edaphosaurus", "Procolophon"
     ),
     bed = c(1, 1, 2, 2, 2, 3, 3, 4),
@@ -71,7 +71,7 @@ test_that("argument 'name' works", {
   )
 
   expect_equal(
-    tax_range_strat(occdf, name = "species"),
+    tax_range_strat(data, name = "species"),
     data.frame(
       ID = 1:4,
       taxon = c("Anconastes", "Procolophon", "Araeoscelis", "Edaphosaurus"),
@@ -85,20 +85,20 @@ test_that("argument 'name' works", {
   # input checks
   # Those give a warning instead of an error on R < 4.3
   skip_if(getRversion() < "4.3")
-  expect_snapshot(tax_range_strat(occdf, name = "test"), error = TRUE)
-  expect_snapshot(tax_range_strat(occdf, name = character(0)), error = TRUE)
-  expect_snapshot(tax_range_strat(occdf, name = NA), error = TRUE)
-  expect_snapshot(tax_range_strat(occdf, name = 1), error = TRUE)
-  nadf <- occdf
+  expect_snapshot(tax_range_strat(data, name = "test"), error = TRUE)
+  expect_snapshot(tax_range_strat(data, name = character(0)), error = TRUE)
+  expect_snapshot(tax_range_strat(data, name = NA), error = TRUE)
+  expect_snapshot(tax_range_strat(data, name = 1), error = TRUE)
+  nadf <- data
   nadf$genus[1] <- NA
   expect_snapshot(tax_range_strat(nadf), error = TRUE)
 })
 
 test_that("argument 'level' works", {
   # fmt: skip
-  occdf <- data.frame(
+  data <- data.frame(
     genus = c(
-      "Anconastes", "Procolophon", "Procolophon", "Anconastes", "Araeoscelis", "Araeoscelis", 
+      "Anconastes", "Procolophon", "Procolophon", "Anconastes", "Araeoscelis", "Araeoscelis",
       "Edaphosaurus", "Procolophon"
     ),
     height = c(1, 1, 2, 2, 2, 3, 3, 4),
@@ -106,7 +106,7 @@ test_that("argument 'level' works", {
   )
 
   expect_equal(
-    tax_range_strat(occdf, level = "height"),
+    tax_range_strat(data, level = "height"),
     data.frame(
       ID = 1:4,
       taxon = c("Anconastes", "Procolophon", "Araeoscelis", "Edaphosaurus"),
@@ -118,20 +118,20 @@ test_that("argument 'level' works", {
   )
 
   # input checks
-  expect_snapshot(tax_range_strat(occdf, level = "test"), error = TRUE)
-  expect_snapshot(tax_range_strat(occdf, level = character(0)), error = TRUE)
-  expect_snapshot(tax_range_strat(occdf, level = NA), error = TRUE)
-  expect_snapshot(tax_range_strat(occdf, level = 1), error = TRUE)
-  nadf <- occdf
+  expect_snapshot(tax_range_strat(data, level = "test"), error = TRUE)
+  expect_snapshot(tax_range_strat(data, level = character(0)), error = TRUE)
+  expect_snapshot(tax_range_strat(data, level = NA), error = TRUE)
+  expect_snapshot(tax_range_strat(data, level = 1), error = TRUE)
+  nadf <- data
   nadf$bed[1] <- NA
   expect_snapshot(tax_range_strat(nadf), error = TRUE)
 })
 
 test_that("argument 'group' works", {
   # fmt: skip
-  occdf <- data.frame(
+  data <- data.frame(
     genus = c(
-      "Anconastes", "Procolophon", "Procolophon", "Anconastes", "Araeoscelis", "Araeoscelis", 
+      "Anconastes", "Procolophon", "Procolophon", "Anconastes", "Araeoscelis", "Araeoscelis",
       "Edaphosaurus", "Procolophon"
     ),
     bed = c(1, 1, 2, 2, 2, 3, 3, 4),
@@ -144,7 +144,7 @@ test_that("argument 'group' works", {
 
   # fmt: skip
   expect_equal(
-    tax_range_strat(occdf, group = "class"),
+    tax_range_strat(data, group = "class"),
     data.frame(
       ID = 1:6,
       taxon = c(
@@ -159,25 +159,25 @@ test_that("argument 'group' works", {
 
   # It produces the expected plot
   expect_doppelganger("tax_range_strat() plots groups", function() {
-    tax_range_strat(occdf, group = "class")
+    tax_range_strat(data, group = "class")
   })
 
   # input checks
   expect_snapshot(
-    tax_range_strat(occdf, group = c("class", "genus")),
+    tax_range_strat(data, group = c("class", "genus")),
     error = TRUE
   )
-  expect_snapshot(tax_range_strat(occdf, group = "test"), error = TRUE)
-  expect_snapshot(tax_range_strat(occdf, group = character(0)), error = TRUE)
-  expect_snapshot(tax_range_strat(occdf, group = NA), error = TRUE)
-  expect_snapshot(tax_range_strat(occdf, group = 1), error = TRUE)
+  expect_snapshot(tax_range_strat(data, group = "test"), error = TRUE)
+  expect_snapshot(tax_range_strat(data, group = character(0)), error = TRUE)
+  expect_snapshot(tax_range_strat(data, group = NA), error = TRUE)
+  expect_snapshot(tax_range_strat(data, group = 1), error = TRUE)
 })
 
 test_that("argument 'certainty' works", {
   # fmt: skip
-  occdf <- data.frame(
+  data <- data.frame(
     genus = c(
-      "Anconastes", "Procolophon", "Procolophon", "Anconastes", "Araeoscelis", "Araeoscelis", 
+      "Anconastes", "Procolophon", "Procolophon", "Anconastes", "Araeoscelis", "Araeoscelis",
       "Edaphosaurus", "Procolophon"
     ),
     bed = c(1, 1, 2, 2, 2, 3, 3, 4),
@@ -186,7 +186,7 @@ test_that("argument 'certainty' works", {
 
   # A certainty column adds columns for the range of certain identifications
   expect_equal(
-    tax_range_strat(occdf, certainty = "certainty"),
+    tax_range_strat(data, certainty = "certainty"),
     data.frame(
       ID = 1:4,
       taxon = c("Anconastes", "Procolophon", "Araeoscelis", "Edaphosaurus"),
@@ -201,28 +201,28 @@ test_that("argument 'certainty' works", {
 
   # It produces the expected plot
   expect_doppelganger("tax_range_strat() does uncertainty", function() {
-    tax_range_strat(occdf, certainty = "certainty")
+    tax_range_strat(data, certainty = "certainty")
   })
 
   # input checks
   expect_snapshot(
-    tax_range_strat(occdf, certainty = c("class", "genus")),
+    tax_range_strat(data, certainty = c("class", "genus")),
     error = TRUE
   )
-  expect_snapshot(tax_range_strat(occdf, certainty = "test"), error = TRUE)
+  expect_snapshot(tax_range_strat(data, certainty = "test"), error = TRUE)
   expect_snapshot(
-    tax_range_strat(occdf, certainty = character(0)),
+    tax_range_strat(data, certainty = character(0)),
     error = TRUE
   )
-  expect_snapshot(tax_range_strat(occdf, certainty = NA), error = TRUE)
-  expect_snapshot(tax_range_strat(occdf, certainty = 1), error = TRUE)
+  expect_snapshot(tax_range_strat(data, certainty = NA), error = TRUE)
+  expect_snapshot(tax_range_strat(data, certainty = 1), error = TRUE)
 })
 
 test_that("argument 'by' works", {
   # fmt: skip
-  occdf <- data.frame(
+  data <- data.frame(
     genus = c(
-      "Anconastes", "Procolophon", "Procolophon", "Anconastes", "Araeoscelis", "Araeoscelis", 
+      "Anconastes", "Procolophon", "Procolophon", "Anconastes", "Araeoscelis", "Araeoscelis",
       "Edaphosaurus", "Procolophon"
     ),
     bed = c(1, 1, 2, 2, 2, 3, 3, 4),
@@ -230,43 +230,43 @@ test_that("argument 'by' works", {
   )
 
   expect_equal(
-    tax_range_strat(occdf, by = "FAD")$taxon,
+    tax_range_strat(data, by = "FAD")$taxon,
     c("Anconastes", "Procolophon", "Araeoscelis", "Edaphosaurus")
   )
   expect_equal(
-    tax_range_strat(occdf, by = "LAD")$taxon,
+    tax_range_strat(data, by = "LAD")$taxon,
     c("Anconastes", "Araeoscelis", "Edaphosaurus", "Procolophon")
   )
   # "name" sorts alphabetically by taxon name
   expect_equal(
-    tax_range_strat(occdf, by = "name")$taxon,
+    tax_range_strat(data, by = "name")$taxon,
     c("Anconastes", "Araeoscelis", "Edaphosaurus", "Procolophon")
   )
 
   # It produces the expected plot
   expect_doppelganger("tax_range_strat() sorts", function() {
-    tax_range_strat(occdf, by = "LAD")
+    tax_range_strat(data, by = "LAD")
   })
 
   # input checks
   expect_snapshot(
-    tax_range_strat(occdf, by = c("FAD", "LAD")),
+    tax_range_strat(data, by = c("FAD", "LAD")),
     error = TRUE
   )
-  expect_snapshot(tax_range_strat(occdf, by = "test"), error = TRUE)
+  expect_snapshot(tax_range_strat(data, by = "test"), error = TRUE)
   expect_snapshot(
-    tax_range_strat(occdf, by = character(0)),
+    tax_range_strat(data, by = character(0)),
     error = TRUE
   )
-  expect_snapshot(tax_range_strat(occdf, by = NA), error = TRUE)
-  expect_snapshot(tax_range_strat(occdf, by = 1), error = TRUE)
+  expect_snapshot(tax_range_strat(data, by = NA), error = TRUE)
+  expect_snapshot(tax_range_strat(data, by = 1), error = TRUE)
 })
 
 test_that("argument 'plot_args' works", {
   # fmt: skip
-  occdf <- data.frame(
+  data <- data.frame(
     genus = c(
-      "Anconastes", "Procolophon", "Procolophon", "Anconastes", "Araeoscelis", "Araeoscelis", 
+      "Anconastes", "Procolophon", "Procolophon", "Anconastes", "Araeoscelis", "Araeoscelis",
       "Edaphosaurus", "Procolophon"
     ),
     bed = c(1, 1, 2, 2, 2, 3, 3, 4),
@@ -275,13 +275,13 @@ test_that("argument 'plot_args' works", {
 
   # Arguments are passed to the underlying plot (e.g. the y-axis label)
   expect_doppelganger("tax_range_strat() labels", function() {
-    tax_range_strat(occdf, plot_args = list(ylab = "Height (m)"))
+    tax_range_strat(data, plot_args = list(ylab = "Height (m)"))
   })
 
   # Unsupported arguments ("type") are overridden rather than passed through
   expect_doppelganger("tax_range_strat() stops some plot_args", function() {
     tax_range_strat(
-      occdf,
+      data,
       plot_args = list(type = "line", ylab = "Height (m)"),
       x_args = list(side = 1),
       y_args = list(side = 2)

--- a/tests/testthat/test-tax_range_time.R
+++ b/tests/testthat/test-tax_range_time.R
@@ -1,12 +1,12 @@
 test_that("basic behaviour works", {
-  occdf <- data.frame(
+  data <- data.frame(
     genus = c("A", "A", "B", "B", "C"),
     max_ma = c(10, 8, 6, 5, 3),
     min_ma = c(9, 7, 5, 4, 2)
   )
 
   expect_equal(
-    tax_range_time(occdf),
+    tax_range_time(data),
     data.frame(
       taxon = c("C", "B", "A"),
       taxon_id = 1:3,
@@ -18,48 +18,48 @@ test_that("basic behaviour works", {
   )
 
   # input checks
-  expect_snapshot(tax_range_time(occdf = data.frame()), error = TRUE)
-  expect_snapshot(tax_range_time(occdf = NULL), error = TRUE)
-  expect_snapshot(tax_range_time(occdf = NA), error = TRUE)
-  expect_snapshot(tax_range_time(occdf = "a"), error = TRUE)
+  expect_snapshot(tax_range_time(data = data.frame()), error = TRUE)
+  expect_snapshot(tax_range_time(data = NULL), error = TRUE)
+  expect_snapshot(tax_range_time(data = NA), error = TRUE)
+  expect_snapshot(tax_range_time(data = "a"), error = TRUE)
 })
 
 test_that("piping and not piping the first argument give the same result", {
-  occdf <- data.frame(
+  data <- data.frame(
     genus = c("A", "A", "B", "B", "C"),
     max_ma = c(10, 8, 6, 5, 3),
     min_ma = c(9, 7, 5, 4, 2)
   )
 
   expect_equal(
-    occdf |> tax_range_time(name = "genus", plot = FALSE),
-    tax_range_time(occdf, name = "genus", plot = FALSE)
+    data |> tax_range_time(name = "genus", plot = FALSE),
+    tax_range_time(data, name = "genus", plot = FALSE)
   )
 })
 
 test_that("tax_range_time errors with unnamed args", {
-  occdf <- data.frame(
+  data <- data.frame(
     genus = c("A", "A", "B"),
     max_ma = c(10, 8, 6),
     min_ma = c(9, 7, 5)
   )
-  expect_snapshot(tax_range_time(occdf, "genus"), error = TRUE)
-  expect_snapshot(tax_range_time(occdf, "genus", "min_ma"), error = TRUE)
+  expect_snapshot(tax_range_time(data, "genus"), error = TRUE)
+  expect_snapshot(tax_range_time(data, "genus", "min_ma"), error = TRUE)
   expect_snapshot(
-    tax_range_time(occdf, "genus", min_ma = "min_ma"),
+    tax_range_time(data, "genus", min_ma = "min_ma"),
     error = TRUE
   )
 })
 
 test_that("argument 'name' works", {
-  occdf <- data.frame(
+  data <- data.frame(
     species = c("A", "A", "B", "B", "C"),
     max_ma = c(10, 8, 6, 5, 3),
     min_ma = c(9, 7, 5, 4, 2)
   )
 
   expect_equal(
-    tax_range_time(occdf, name = "species"),
+    tax_range_time(data, name = "species"),
     data.frame(
       taxon = c("C", "B", "A"),
       taxon_id = 1:3,
@@ -71,7 +71,7 @@ test_that("argument 'name' works", {
   )
 
   # the "name" column must not contain NA values
-  nadf <- occdf
+  nadf <- data
   nadf$species[1] <- NA
   expect_snapshot(
     tax_range_time(nadf, name = "species"),
@@ -80,27 +80,27 @@ test_that("argument 'name' works", {
 
   # input checks
   expect_snapshot(
-    tax_range_time(occdf, name = c("Species", "max_ma")),
+    tax_range_time(data, name = c("Species", "max_ma")),
     error = TRUE
   )
-  expect_snapshot(tax_range_time(occdf, name = "nonexistent"), error = TRUE)
-  expect_snapshot(tax_range_time(occdf, name = 1), error = TRUE)
-  expect_snapshot(tax_range_time(occdf, name = NA), error = TRUE)
+  expect_snapshot(tax_range_time(data, name = "nonexistent"), error = TRUE)
+  expect_snapshot(tax_range_time(data, name = 1), error = TRUE)
+  expect_snapshot(tax_range_time(data, name = NA), error = TRUE)
 
   # Snapshot is slightly different with R < 4.3
   skip_if(getRversion() < "4.3.0")
-  expect_snapshot(tax_range_time(occdf, name = NULL), error = TRUE)
+  expect_snapshot(tax_range_time(data, name = NULL), error = TRUE)
 })
 
 test_that("argument 'max_ma' works", {
-  occdf <- data.frame(
+  data <- data.frame(
     genus = c("A", "A", "B", "B", "C"),
     p_max_ma = c(10, 8, 6, 5, 3),
     min_ma = c(9, 7, 5, 4, 2)
   )
 
   expect_equal(
-    tax_range_time(occdf, max_ma = "p_max_ma"),
+    tax_range_time(data, max_ma = "p_max_ma"),
     data.frame(
       taxon = c("C", "B", "A"),
       taxon_id = 1:3,
@@ -113,13 +113,13 @@ test_that("argument 'max_ma' works", {
 
   # input checks
   expect_snapshot(
-    tax_range_time(occdf, max_ma = c("Species", "max_ma")),
+    tax_range_time(data, max_ma = c("Species", "max_ma")),
     error = TRUE
   )
-  expect_snapshot(tax_range_time(occdf, max_ma = "nonexistent"), error = TRUE)
-  expect_snapshot(tax_range_time(occdf, max_ma = 1), error = TRUE)
-  expect_snapshot(tax_range_time(occdf, max_ma = NA), error = TRUE)
-  expect_snapshot(tax_range_time(occdf, max_ma = NULL), error = TRUE)
+  expect_snapshot(tax_range_time(data, max_ma = "nonexistent"), error = TRUE)
+  expect_snapshot(tax_range_time(data, max_ma = 1), error = TRUE)
+  expect_snapshot(tax_range_time(data, max_ma = NA), error = TRUE)
+  expect_snapshot(tax_range_time(data, max_ma = NULL), error = TRUE)
 
   # the "max_ma" column must be numeric
   chardf <- data.frame(genus = "a", max_ma = "10", min_ma = 5)
@@ -136,14 +136,14 @@ test_that("argument 'max_ma' works", {
 })
 
 test_that("argument 'min_ma' works", {
-  occdf <- data.frame(
+  data <- data.frame(
     genus = c("A", "A", "B", "B", "C"),
     max_ma = c(10, 8, 6, 5, 3),
     p_min_ma = c(9, 7, 5, 4, 2)
   )
 
   expect_equal(
-    tax_range_time(occdf, min_ma = "p_min_ma"),
+    tax_range_time(data, min_ma = "p_min_ma"),
     data.frame(
       taxon = c("C", "B", "A"),
       taxon_id = 1:3,
@@ -156,13 +156,13 @@ test_that("argument 'min_ma' works", {
 
   # input checks
   expect_snapshot(
-    tax_range_time(occdf, min_ma = c("Species", "min_ma")),
+    tax_range_time(data, min_ma = c("Species", "min_ma")),
     error = TRUE
   )
-  expect_snapshot(tax_range_time(occdf, min_ma = "nonexistent"), error = TRUE)
-  expect_snapshot(tax_range_time(occdf, min_ma = 1), error = TRUE)
-  expect_snapshot(tax_range_time(occdf, min_ma = NA), error = TRUE)
-  expect_snapshot(tax_range_time(occdf, min_ma = NULL), error = TRUE)
+  expect_snapshot(tax_range_time(data, min_ma = "nonexistent"), error = TRUE)
+  expect_snapshot(tax_range_time(data, min_ma = 1), error = TRUE)
+  expect_snapshot(tax_range_time(data, min_ma = NA), error = TRUE)
+  expect_snapshot(tax_range_time(data, min_ma = NULL), error = TRUE)
 
   # the "min_ma" column must be numeric
   chardf <- data.frame(genus = "a", max_ma = 10, min_ma = "5")
@@ -179,16 +179,16 @@ test_that("argument 'min_ma' works", {
 })
 
 test_that("max ages must be larger than or equal to min ages", {
-  occdf <- data.frame(
+  data <- data.frame(
     genus = c("A", "B", "C"),
     max_ma = c(150, 100, 30),
     min_ma = c(110, 110, 40)
   )
-  expect_snapshot(tax_range_time(occdf), error = TRUE)
+  expect_snapshot(tax_range_time(data), error = TRUE)
 })
 
 test_that("argument 'group' works", {
-  occdf <- data.frame(
+  data <- data.frame(
     genus = c("A", "A", "B", "B", "C"),
     max_ma = c(10, 8, 6, 5, 3),
     min_ma = c(9, 7, 5, 4, 2),
@@ -196,7 +196,7 @@ test_that("argument 'group' works", {
   )
 
   expect_equal(
-    tax_range_time(occdf, group = "family"),
+    tax_range_time(data, group = "family"),
     data.frame(
       taxon = c("B", "A", "C", "B"),
       taxon_id = 1:4,
@@ -210,23 +210,23 @@ test_that("argument 'group' works", {
 
   # input checks
   expect_snapshot(
-    tax_range_time(occdf, group = c("genus", "min_ma")),
+    tax_range_time(data, group = c("genus", "min_ma")),
     error = TRUE
   )
-  expect_snapshot(tax_range_time(occdf, group = "nonexistent"), error = TRUE)
-  expect_snapshot(tax_range_time(occdf, group = 1), error = TRUE)
-  expect_snapshot(tax_range_time(occdf, group = NA), error = TRUE)
+  expect_snapshot(tax_range_time(data, group = "nonexistent"), error = TRUE)
+  expect_snapshot(tax_range_time(data, group = 1), error = TRUE)
+  expect_snapshot(tax_range_time(data, group = NA), error = TRUE)
 })
 
 test_that("argument 'by' works", {
-  occdf <- data.frame(
+  data <- data.frame(
     genus = c("A", "A", "B", "B", "C"),
     max_ma = c(10, 8, 6, 5, 3),
     min_ma = c(9, 7, 5, 4, 2)
   )
 
   expect_equal(
-    tax_range_time(occdf),
+    tax_range_time(data),
     data.frame(
       taxon = c("C", "B", "A"),
       taxon_id = 1:3,
@@ -237,7 +237,7 @@ test_that("argument 'by' works", {
     )
   )
   expect_equal(
-    tax_range_time(occdf, by = "LAD"),
+    tax_range_time(data, by = "LAD"),
     data.frame(
       taxon = c("C", "B", "A"),
       taxon_id = 1:3,
@@ -248,7 +248,7 @@ test_that("argument 'by' works", {
     )
   )
   expect_equal(
-    tax_range_time(occdf, by = "name"),
+    tax_range_time(data, by = "name"),
     data.frame(
       taxon = c("A", "B", "C"),
       taxon_id = 1:3,
@@ -261,16 +261,16 @@ test_that("argument 'by' works", {
 
   # input checks
   expect_snapshot(
-    tax_range_time(occdf, by = c("genus", "min_ma")),
+    tax_range_time(data, by = c("genus", "min_ma")),
     error = TRUE
   )
-  expect_snapshot(tax_range_time(occdf, by = "nonexistent"), error = TRUE)
-  expect_snapshot(tax_range_time(occdf, by = 1), error = TRUE)
-  expect_snapshot(tax_range_time(occdf, by = NA), error = TRUE)
+  expect_snapshot(tax_range_time(data, by = "nonexistent"), error = TRUE)
+  expect_snapshot(tax_range_time(data, by = 1), error = TRUE)
+  expect_snapshot(tax_range_time(data, by = NA), error = TRUE)
 })
 
 test_that("argument 'plot' works", {
-  occdf <- data.frame(
+  data <- data.frame(
     genus = c("A", "A", "B", "B", "C"),
     max_ma = c(10, 8, 6, 5, 3),
     min_ma = c(9, 7, 5, 4, 2)
@@ -278,27 +278,27 @@ test_that("argument 'plot' works", {
 
   # The returned data.frame is identical whether or not a plot is produced
   expect_equal(
-    tax_range_time(occdf, plot = TRUE),
-    tax_range_time(occdf, plot = FALSE)
+    tax_range_time(data, plot = TRUE),
+    tax_range_time(data, plot = FALSE)
   )
 
   expect_doppelganger("tax_range_time() works", function() {
-    tax_range_time(occdf)
+    tax_range_time(data)
   })
   expect_doppelganger("tax_range_time() works with LAD sorting", function() {
-    tax_range_time(occdf, by = "LAD")
+    tax_range_time(data, by = "LAD")
   })
   expect_doppelganger("tax_range_time() works with name sorting", function() {
-    tax_range_time(occdf, by = "name")
+    tax_range_time(data, by = "name")
   })
 
   # input checks
-  expect_snapshot(tax_range_time(occdf, plot = "test"), error = TRUE)
-  expect_snapshot(tax_range_time(occdf, plot = NA), error = TRUE)
+  expect_snapshot(tax_range_time(data, plot = "test"), error = TRUE)
+  expect_snapshot(tax_range_time(data, plot = NA), error = TRUE)
 })
 
 test_that("argument 'plot_args' works", {
-  occdf <- data.frame(
+  data <- data.frame(
     genus = c("A", "A", "B", "B", "C"),
     max_ma = c(10, 8, 6, 5, 3),
     min_ma = c(9, 7, 5, 4, 2)
@@ -306,21 +306,21 @@ test_that("argument 'plot_args' works", {
 
   # Passing plot_args does not change the returned data.frame
   expect_equal(
-    tax_range_time(occdf, plot = TRUE, plot_args = list(ylab = "Taxa")),
-    tax_range_time(occdf, plot = FALSE)
+    tax_range_time(data, plot = TRUE, plot_args = list(ylab = "Taxa")),
+    tax_range_time(data, plot = FALSE)
   )
 
   expect_doppelganger("tax_range_time() works with plot args", function() {
-    tax_range_time(occdf, plot_args = list(ylab = "Taxa"))
+    tax_range_time(data, plot_args = list(ylab = "Taxa"))
   })
 
   # input checks
-  expect_snapshot(tax_range_time(occdf, plot_args = "test"), error = TRUE)
-  expect_snapshot(tax_range_time(occdf, plot_args = NA), error = TRUE)
+  expect_snapshot(tax_range_time(data, plot_args = "test"), error = TRUE)
+  expect_snapshot(tax_range_time(data, plot_args = NA), error = TRUE)
 })
 
 test_that("argument 'intervals' works", {
-  occdf <- data.frame(
+  data <- data.frame(
     genus = c("A", "A", "B", "B", "C"),
     max_ma = c(10, 8, 6, 5, 3),
     min_ma = c(9, 7, 5, 4, 2)
@@ -328,8 +328,8 @@ test_that("argument 'intervals' works", {
 
   # Passing intervals does not change the returned data.frame
   expect_equal(
-    tax_range_time(occdf, plot = TRUE, intervals = "epochs"),
-    tax_range_time(occdf, plot = FALSE)
+    tax_range_time(data, plot = TRUE, intervals = "epochs"),
+    tax_range_time(data, plot = FALSE)
   )
 
   # input checks
@@ -339,31 +339,31 @@ test_that("argument 'intervals' works", {
   # The validation of "intervals" should come earlier in the function, before creating the plot.
 
   # expect_snapshot(
-  #   tax_range_time(occdf, plot = TRUE, intervals = c("genus", "min_ma")),
+  #   tax_range_time(data, plot = TRUE, intervals = c("genus", "min_ma")),
   #   error = TRUE
   # )
   # expect_snapshot(
-  #   tax_range_time(occdf, plot = TRUE, intervals = "nonexistent"),
+  #   tax_range_time(data, plot = TRUE, intervals = "nonexistent"),
   #   error = TRUE
   # )
   # expect_snapshot(
-  #   tax_range_time(occdf, plot = TRUE, intervals = 1),
+  #   tax_range_time(data, plot = TRUE, intervals = 1),
   #   error = TRUE
   # )
   # expect_snapshot(
-  #   tax_range_time(occdf, plot = TRUE, intervals = NA),
+  #   tax_range_time(data, plot = TRUE, intervals = NA),
   #   error = TRUE
   # )
 
   # TODO: should these error if plot = FALSE since intervals would be irrelevant in this case?
   # expect_snapshot(
-  #   tax_range_time(occdf, intervals = c("genus", "min_ma")),
+  #   tax_range_time(data, intervals = c("genus", "min_ma")),
   #   error = TRUE
   # )
   # expect_snapshot(
-  #   tax_range_time(occdf, intervals = "nonexistent"),
+  #   tax_range_time(data, intervals = "nonexistent"),
   #   error = TRUE
   # )
-  # expect_snapshot(tax_range_time(occdf, intervals = 1), error = TRUE)
-  # expect_snapshot(tax_range_time(occdf, intervals = NA), error = TRUE)
+  # expect_snapshot(tax_range_time(data, intervals = 1), error = TRUE)
+  # expect_snapshot(tax_range_time(data, intervals = NA), error = TRUE)
 })

--- a/tests/testthat/test-tax_unique.R
+++ b/tests/testthat/test-tax_unique.R
@@ -13,7 +13,7 @@ test_that("basic behaviour works", {
   # fmt: skip
   expect_equal(
     tax_unique(
-      occdf = dinosaurs,
+      data = dinosaurs,
       species = "species",
       genus = "genus",
       family = "family",
@@ -84,7 +84,7 @@ test_that("piping and not piping the first argument give the same result", {
 
   expect_equal(
     tax_unique(
-      occdf = dinosaurs,
+      data = dinosaurs,
       species = "species",
       genus = "genus",
       family = "family",
@@ -154,14 +154,14 @@ test_that("arg 'binomial' works", {
   # `species` and `genus` columns.
   expect_equal(
     tax_unique(
-      occdf = dinosaurs,
+      data = dinosaurs,
       binomial = "binomial",
       family = "family",
       order = "order",
       class = "class"
     ),
     tax_unique(
-      occdf = dinosaurs,
+      data = dinosaurs,
       species = "species",
       genus = "genus",
       family = "family",
@@ -176,7 +176,7 @@ test_that("arg 'binomial' works", {
   # dinosaurs$binomial <- gsub(" ", "_", dinosaurs$binomial)
   # expect_equal(
   #   tax_unique(
-  #     occdf = dinosaurs,
+  #     data = dinosaurs,
   #     binomial = "binomial",
   #     family = "family",
   #     order = "order",
@@ -206,7 +206,7 @@ test_that("arg 'name' works", {
 
   expect_equal(
     tax_unique(
-      occdf = dinosaurs,
+      data = dinosaurs,
       genus = "genus",
       family = "family",
       class = "class",
@@ -275,7 +275,7 @@ test_that("higher taxonomic levels supplied via `...` work", {
 
   # at least one higher level is required
   expect_snapshot(
-    tax_unique(occdf = dinosaurs, species = "species", genus = "genus"),
+    tax_unique(data = dinosaurs, species = "species", genus = "genus"),
     error = TRUE
   )
 
@@ -324,7 +324,7 @@ test_that("arg 'resolution' works", {
   # higher-level-only occurrences are still retained as cryptic diversity.
   expect_equal(
     tax_unique(
-      occdf = dinosaurs,
+      data = dinosaurs,
       binomial = "binomial",
       family = "family",
       order = "order",
@@ -348,7 +348,7 @@ test_that("arg 'resolution' works", {
   # a `genus` column alone (no `binomial`) is enough at genus resolution
   expect_equal(
     tax_unique(
-      occdf = dinosaurs,
+      data = dinosaurs,
       genus = "genus",
       family = "family",
       order = "order",
@@ -366,7 +366,7 @@ test_that("arg 'resolution' works", {
   # input checks
   expect_snapshot(
     tax_unique(
-      occdf = dinosaurs,
+      data = dinosaurs,
       species = "species",
       genus = "genus",
       family = "family",
@@ -376,7 +376,7 @@ test_that("arg 'resolution' works", {
   )
   expect_snapshot(
     tax_unique(
-      occdf = dinosaurs,
+      data = dinosaurs,
       species = "species",
       genus = "genus",
       family = "family",
@@ -386,7 +386,7 @@ test_that("arg 'resolution' works", {
   )
   expect_snapshot(
     tax_unique(
-      occdf = dinosaurs,
+      data = dinosaurs,
       species = "species",
       genus = "genus",
       family = "family",
@@ -409,7 +409,7 @@ test_that("arg 'append' works", {
 
   expect_equal(
     tax_unique(
-      occdf = dinosaurs,
+      data = dinosaurs,
       species = "species",
       genus = "genus",
       family = "family",
@@ -480,7 +480,7 @@ test_that("taxonomic columns must not contain punctuation", {
 
   expect_snapshot(
     tax_unique(
-      occdf = tetrapods,
+      data = tetrapods,
       genus = "identified_name",
       family = "family",
       resolution = "genus"
@@ -489,7 +489,7 @@ test_that("taxonomic columns must not contain punctuation", {
   )
   expect_snapshot(
     tax_unique(
-      occdf = tetrapods,
+      data = tetrapods,
       genus = "genus",
       family = "identified_name",
       resolution = "genus"
@@ -498,7 +498,7 @@ test_that("taxonomic columns must not contain punctuation", {
   )
   expect_snapshot(
     tax_unique(
-      occdf = tetrapods,
+      data = tetrapods,
       species = "identified_name",
       genus = "genus",
       family = "family",

--- a/vignettes/phanerozoic-reefs.Rmd
+++ b/vignettes/phanerozoic-reefs.Rmd
@@ -91,7 +91,7 @@ Not bad (*n* = `r nrow(palaeoverse::reefs)`), that's quite a bit of data to play
 ```{r echo = TRUE, eval = TRUE}
 # How many reefs per interval?
 # Let's group by the interval column to test
-reef_counts <- group_apply(occdf = reefs, group = "interval", fun = nrow)
+reef_counts <- group_apply(data = reefs, group = "interval", fun = nrow)
 head(reef_counts)
 ```
 
@@ -101,7 +101,7 @@ Oh dear, we've just hit a common issue... our reef data does not conform to a co
 # Load the interval key
 data("interval_key")
 # Assign a common time scale based on an interval key
-reefs <- look_up(occdf = reefs,
+reefs <- look_up(data = reefs,
                  early_interval = "interval",
                  late_interval = "interval",
                  int_key = interval_key)
@@ -128,20 +128,20 @@ colnames(reefs)[which(colnames(reefs) == "interval_min_ma")] <- "min_ma"
 # Five methods exist in bin_time for binning occurrence data
 # You can see details on each via ?bin_time
 # Bin by midpoint age
-bin_time(occdf = reefs, bins = bins, method = "mid")
+bin_time(data = reefs, bins = bins, method = "mid")
 # Bin by overlap majority
-bin_time(occdf = reefs, bins = bins, method = "majority")
+bin_time(data = reefs, bins = bins, method = "majority")
 # Bin into every bin within age range
-bin_time(occdf = reefs, bins = bins, method = "all")
+bin_time(data = reefs, bins = bins, method = "all")
 # Bin randomly into bins within age range (equal probability)
-bin_time(occdf = reefs, bins = bins, method = "random", reps = 10)
+bin_time(data = reefs, bins = bins, method = "random", reps = 10)
 # Bin randomly into bins within age range (uniform probability)
-bin_time(occdf = reefs, bins = bins, method = "point", reps = 10)
+bin_time(data = reefs, bins = bins, method = "point", reps = 10)
 ```
 
 ```{r echo = TRUE, eval = TRUE}
 # Let's go with "all" for this example!
-reefs <- bin_time(occdf = reefs, bins = bins, method = "all")
+reefs <- bin_time(data = reefs, bins = bins, method = "all")
 ```
 
 Note that the number of rows of `reefs` have now increased. This is because the "all" method in `bin_time` duplicates an occurrence for every bin the age range overlaps with.
@@ -150,7 +150,7 @@ Let's check those reef numbers through time again using our binned data:
 
 ```{r echo = TRUE, eval = TRUE}
 # Count number of occurrences per interval
-reefs_time <- group_apply(occdf = reefs, group = "interval_mid_ma", fun = nrow)
+reefs_time <- group_apply(data = reefs, group = "interval_mid_ma", fun = nrow)
 # Check output
 head(reefs_time)
 ```
@@ -174,11 +174,11 @@ You would (and should) of course want to explore your data a little more than th
 
 When studying modern latitudinal trends (e.g. in biodiversity), researchers can use the geographic coordinates of their samples to conduct analyses. However, as the continents shift through time, palaeobiologists must reconstruct the palaeogeographic coordinates of fossil localities. To do so, plate rotation models are used (e.g. the PALEOMAP model) to rotate the modern coordinates of fossil localities to their location at time of deposition. The `palaeorotate` function allows the user to do so using either the 'point' or 'grid' method. The first approach makes use of the GPlates Web Service and allows point data to be rotated to specific ages using the available models (see the [GPlates Web Service documentation](https://gwsdoc.gplates.org)). The second approach uses reconstruction files of pre-generated palaeocoordinates to spatiotemporally link occurrences' modern coordinates and age estimates with their respective palaeocoordinates. Let's give it a shot:
 
-<!-- 
+<!--
 The following four chunks are here to handle the absence or the presence of an RDS file
 containing the results of palaeorotate():
 - if the RDS is present, then we don't evaluate palaeorotate() and read the RDS instead
-- if the RDS is absent, then we evaluate palaeorotate() and save its output in the RDS 
+- if the RDS is absent, then we evaluate palaeorotate() and save its output in the RDS
 -->
 
 ```{r echo = FALSE, eval = TRUE}
@@ -187,7 +187,7 @@ rds_point_paleomap_reefs_exists <- file.exists("_data/palaeorotate_point_paleoma
 
 ```{r echo = TRUE, eval = !rds_point_paleomap_reefs_exists}
 # Palaeorotate occurrences
-reefs <- palaeorotate(occdf = reefs, age = "bin_midpoint",
+reefs <- palaeorotate(data = reefs, age = "bin_midpoint",
                       method = "point", model = "PALEOMAP")
 ```
 
@@ -247,11 +247,11 @@ axis_geo(side = 1, intervals = "periods")
 
 That's definitely much clearer! Should we stop there? Well... how about one last thing... let's consider how plate rotation model choice might impact these results using three different models: GOLONKA, PALEOMAP, and MERDITH2021 (Wright et al. 2013; Scotese & Wright, 2018; Merdith et al. 2021).
 
-<!-- 
+<!--
 The following four chunks are here to handle the absence or the presence of an RDS file
 containing the results of palaeorotate():
 - if the RDS is present, then we don't evaluate palaeorotate() and read the RDS instead
-- if the RDS is absent, then we evaluate palaeorotate() and save its output in the RDS 
+- if the RDS is absent, then we evaluate palaeorotate() and save its output in the RDS
 -->
 
 ```{r echo = FALSE, eval = TRUE}
@@ -263,7 +263,7 @@ rds_point_multi_models_exists <- file.exists("_data/palaeorotate_point_multi_mod
 # First, let's define the models...
 models <- c("GOLONKA", "PALEOMAP", "MERDITH2021")
 # And now palaeorotate!
-reefs <- palaeorotate(occdf = reefs, age = "bin_midpoint",
+reefs <- palaeorotate(data = reefs, age = "bin_midpoint",
                       method = "point", model = models)
 ```
 
@@ -289,14 +289,14 @@ Now we've palaeorotated our data, let's repeat what we did earlier and calculate
 ```{r, reefs-max-multi, echo = TRUE, eval = TRUE}
 # Let's code a little helper function to begin with.
 # This is generally useful when repeating code several times!
-p_lat_max <- function(occdf, midpoint, p_lat) {
+p_lat_max <- function(data, midpoint, p_lat) {
   # Get absolute palaeolatitudes
-  occdf[, p_lat] <- abs(occdf[, p_lat])
+  data[, p_lat] <- abs(data[, p_lat])
   # Extract unique bin midpoints
-  midpoints <- sort(unique(occdf[, midpoint]))
+  midpoints <- sort(unique(data[, midpoint]))
   # Calculate maximum palaeolatitude for each bin
   lat_max <- sapply(X = midpoints, FUN = function(x) {
-    max(occdf[which(occdf[, midpoint] == x), ][, p_lat], na.rm = TRUE)
+    max(data[which(data[, midpoint] == x), ][, p_lat], na.rm = TRUE)
   })
   # Bind data
   lat_max <- cbind.data.frame(midpoints, lat_max)
@@ -304,13 +304,13 @@ p_lat_max <- function(occdf, midpoint, p_lat) {
   return(lat_max)
 }
 # Calculate maximum palaeolatitude of reefs for each time bin for each model
-paleomap <- p_lat_max(occdf = reefs,
+paleomap <- p_lat_max(data = reefs,
                       midpoint = "bin_midpoint",
                       p_lat = "p_lat_PALEOMAP")
-golonka <- p_lat_max(occdf = reefs,
+golonka <- p_lat_max(data = reefs,
                      midpoint = "bin_midpoint",
                      p_lat = "p_lat_GOLONKA")
-merdith <- p_lat_max(occdf = reefs,
+merdith <- p_lat_max(data = reefs,
                      midpoint = "bin_midpoint",
                      p_lat = "p_lat_MERDITH2021")
 # Set up plot

--- a/vignettes/structure-and-standards.Rmd
+++ b/vignettes/structure-and-standards.Rmd
@@ -7,21 +7,21 @@ vignette: >
   %\VignetteEncoding{UTF-8}
 ---
 
-<div style="text-align: justify"> 
+<div style="text-align: justify">
 
 # Introduction
 
 The `palaeoverse` R package is a community-driven software library providing generic tools for palaeobiological analysis. The core principles of palaeoverse are to: (1) streamline analyses, (2) enhance code readability, and (3) improve reproducibility of results.
 
-This document describes the essential structure and conventions of the `palaeoverse` R package. Naturally, there are always disagreements regarding best practices and conventions, and `palaeoverse` is no exception. Despite this, all the essentials in `palaeoverse` are encouraged to make the lives of both the developer, and the user, easier. It is worth noting that the core structure and conventions adopted in `palaeoverse` are heavily influenced by Hadley Wickham and Jenny Bryan's [R Packages](https://r-pkgs.org/index.html) and the [tidyverse style guide](https://style.tidyverse.org/index.html), which is currently also Google's guide.  
+This document describes the essential structure and conventions of the `palaeoverse` R package. Naturally, there are always disagreements regarding best practices and conventions, and `palaeoverse` is no exception. Despite this, all the essentials in `palaeoverse` are encouraged to make the lives of both the developer, and the user, easier. It is worth noting that the core structure and conventions adopted in `palaeoverse` are heavily influenced by Hadley Wickham and Jenny Bryan's [R Packages](https://r-pkgs.org/index.html) and the [tidyverse style guide](https://style.tidyverse.org/index.html), which is currently also Google's guide.
 <br>
 
 ***"Good coding style is like correct punctuation: you can manage without it, butitsuremakesthingseasiertoread." -- tidyverse style guide***
 
 # Files
 
-File names should always be concise, meaningful and end in `'.R'`. Avoid using special characters whenever possible (i.e. stick to letters and numbers), and use `'_'` or `'-'` instead of spaces in file names. The use of lowercase is also strongly encouraged, and **never** have file names that only differ in capitalization. **Note:** the preferred separator is `'_'` to consist with the 'lowercase snake_case' convention for developing functions (more on that later!).  
-<br>  
+File names should always be concise, meaningful and end in `'.R'`. Avoid using special characters whenever possible (i.e. stick to letters and numbers), and use `'_'` or `'-'` instead of spaces in file names. The use of lowercase is also strongly encouraged, and **never** have file names that only differ in capitalization. **Note:** the preferred separator is `'_'` to consist with the 'lowercase snake_case' convention for developing functions (more on that later!).
+<br>
 
 ```{r names, include=TRUE, eval = FALSE}
 
@@ -33,7 +33,6 @@ super_awesome_function.R
 
 # Das ist gut!
 time_bins.R
-
 ```
 
 # R style guide
@@ -60,8 +59,8 @@ We recommend using the following conventions to make your code easier for us (an
 
 ```{r style guide, include=TRUE, eval = FALSE}
 # Nope!
-x = 1
-y<-x+1
+x <- 1
+y <- x + 1
 
 # Awesome!
 x <- 1
@@ -82,7 +81,7 @@ However, for the sake of file size efficiency, please only include data and vari
 Raw data should always be included in `inst/extdata`. If you want to include cleaned/processed data in `data/`, it is generally a good idea to include the code used to process the raw data. If you ever need to reproduce or update your cleaned data, this will save you precious time. The code for processing your data should be included in `data-raw/`. Strictly speaking, raw data does not need to be documented. However, it is a good idea to include the original source and version (including a download date) in your code.
 
 ## Internal data
-Data you do not wish to directly make available to the user should be saved as `R/sysdata.rda`. This is the best option for pre-computed data tables that are needed for a function to run. Strictly speaking internal data does not need to be documented. However, it is a good idea to document the internal data in the function documentation. 
+Data you do not wish to directly make available to the user should be saved as `R/sysdata.rda`. This is the best option for pre-computed data tables that are needed for a function to run. Strictly speaking internal data does not need to be documented. However, it is a good idea to document the internal data in the function documentation.
 
 ## Exported data
 Package data you wish to make available to the user should be stored in `data/`. Each file in this directory should be either a `'.rda'` or `'.RData'`. This file type is fast, small and explicit. The most appropriate way to include exported data is to use `usethis::use_data()`.
@@ -107,7 +106,7 @@ unlink(x = paste0(files, "/", list.files(files)))
 ```
 
 ## Data documentation
-Objects in `data/` are always exported by default, and should be documented accordingly. In order to properly document data, you must document the name of the dataset and save it in `R/data`. For example, the documentation block used to document GTS2020 is saved as `R/data.R` and is similar to the following (simplified here): 
+Objects in `data/` are always exported by default, and should be documented accordingly. In order to properly document data, you must document the name of the dataset and save it in `R/data`. For example, the documentation block used to document GTS2020 is saved as `R/data.R` and is similar to the following (simplified here):
 
 ```{r document, include = TRUE, eval = FALSE}
 #' Geological Time Scale 2020
@@ -136,7 +135,7 @@ Objects in `data/` are always exported by default, and should be documented acco
 ## What does it mean to document your data?
 Documenting your data is to provide a thorough description of the data and any information relevant to understanding it. Good documentation is key to reproducible science, and will also help us to ensure that we acknowledge all data collators who have provided data for the `palaeoverse` package. When providing us with datasets, please give the following information:
 
-**Author(s):** Who collected the data, and prepared its current format? Please provide citations if relevant. Have the authors given permission for the dataset to be included in the `palaeoverse` package? 
+**Author(s):** Who collected the data, and prepared its current format? Please provide citations if relevant. Have the authors given permission for the dataset to be included in the `palaeoverse` package?
 
 **Description:** Brief description of the dataset.
 
@@ -148,7 +147,7 @@ Documenting your data is to provide a thorough description of the data and any i
 
 # Functions
 ## Conventions
-Functions are saved as `'.R'` files in the `'R'` folder. The name of the file needs to correspond to the function, e.g. the file `time_bins.R` contains the function `time_bins()`. Function names and arguments should be informative and aim to keep in line with available functions in `palaeoverse`. For example, all functions that bin data, whether it be by time or space, start with `bin_`, whereas taxonomic-related functions start with `tax_` (e.g. `tax_unique`, `tax_check`). Where possible, argument names should also consist with functions in the package. For example, if a function requires an occurrence dataframe as input, the argument name should be `occdf`. It is difficult to give a complete static summary of all the conventions as `palaeoverse` will undoubtedly evolve over time. We also wish to remain flexible for contributors, provided that it does not compromise the user-friendliness of the package. We welcome contributors to check through the source code of `palaeoverse` for function examples.
+Functions are saved as `'.R'` files in the `'R'` folder. The name of the file needs to correspond to the function, e.g. the file `time_bins.R` contains the function `time_bins()`. Function names and arguments should be informative and aim to keep in line with available functions in `palaeoverse`. For example, all functions that bin data, whether it be by time or space, start with `bin_`, whereas taxonomic-related functions start with `tax_` (e.g. `tax_unique`, `tax_check`). Where possible, argument names should also consist with functions in the package. For example, if a function requires a dataframe as input, the argument name should be `data`. It is difficult to give a complete static summary of all the conventions as `palaeoverse` will undoubtedly evolve over time. We also wish to remain flexible for contributors, provided that it does not compromise the user-friendliness of the package. We welcome contributors to check through the source code of `palaeoverse` for function examples.
 
 ## Documentation
 For documentation, we use [roxygen2](https://roxygen2.r-lib.org). The title, a brief description, and every argument (including the input class and default input) and the output of the function need to be documented in `roxygen2` style, for example:
@@ -192,7 +191,7 @@ Examples of error messages include
 - input without mandatory names, e.g. `“Error: 'x' does not have a column 'stage'.`
 `'x' must be a data.frame with the columns 'stage' and 'age'.”`
 
-To implement error messages in R, the `stop()` function can be used: 
+To implement error messages in R, the `stop()` function can be used:
 
 ```{r error, include = TRUE, eval = FALSE}
 # Generate error message

--- a/vignettes/tetrapod-biodiversity.Rmd
+++ b/vignettes/tetrapod-biodiversity.Rmd
@@ -118,7 +118,7 @@ colnames(tetrapods)[9:10] <- c("old_max_ma", "old_min_ma")
 colnames(tetrapods)[c(35, 37)] <- c("max_ma", "min_ma")
 
 # Generate time bins
-tetrapods <- bin_time(occdf = tetrapods,
+tetrapods <- bin_time(data = tetrapods,
                       bins = bins,
                       method = "mid")
 ```
@@ -130,7 +130,7 @@ Oh no! We've hit an error. This is because there's some occurrences that sit out
 cp_tetrapods <- subset(tetrapods, min_ma > min(bins$min_ma))
 
 # Bin occurrences into chosen time bins
-mid_tetrapods <- bin_time(occdf = cp_tetrapods,
+mid_tetrapods <- bin_time(data = cp_tetrapods,
                           bins = bins,
                           method = "mid")
 ```
@@ -154,7 +154,7 @@ As you can see, only ~25% of the dataset can be assigned to just one bin - the o
 
 ```{r}
 # Bin occurrences into chosen time bins
-maj_tetrapods <- bin_time(occdf = cp_tetrapods,
+maj_tetrapods <- bin_time(data = cp_tetrapods,
                           bins = bins,
                           method = "majority")
 ```
@@ -163,11 +163,11 @@ We'd recommend playing around with these different options and seeing how they i
 
 Next, we'll also bin our occurrences spatially. We need a couple of functions to do this. Firstly, we need to add palaeocoordinates to our dataset. We can use the `palaeorotate` function to do this.
 
-<!-- 
+<!--
 The following four chunks are here to handle the absence or the presence of an RDS file
 containing the results of palaeorotate():
 - if the RDS is present, then we don't evaluate palaeorotate() and read the RDS instead
-- if the RDS is absent, then we evaluate palaeorotate() and save its output in the RDS 
+- if the RDS is absent, then we evaluate palaeorotate() and save its output in the RDS
 -->
 
 ```{r echo = FALSE, eval = TRUE}
@@ -176,7 +176,7 @@ rds_point_paleomap_tetrapods_exists <- file.exists("_data/palaeorotate_point_pal
 
 ```{r echo = TRUE, eval = !rds_point_paleomap_tetrapods_exists}
 # Palaeorotate occurrences
-maj_tetrapods <- palaeorotate(occdf = maj_tetrapods, age = "bin_midpoint",
+maj_tetrapods <- palaeorotate(data = maj_tetrapods, age = "bin_midpoint",
                               method = "point", model = "PALEOMAP")
 ```
 
@@ -199,7 +199,7 @@ Looks good to me! Now that we have palaeocoordinates for our occurrences, we can
 
 ```{r}
 # Make a table of potential number of bins
-maj_tetrapods <- bin_space(occdf = maj_tetrapods,
+maj_tetrapods <- bin_space(data = maj_tetrapods,
                            lng = "p_lng",
                            lat = "p_lat",
                            spacing = 100)
@@ -239,7 +239,7 @@ This function can be especially useful for when looking at alpha diversity (loca
 
 ```{r}
 # Filter to genus-level:
-tet_genera <- tax_unique(occdf = maj_tetrapods, genus = "genus", family = "family",
+tet_genera <- tax_unique(data = maj_tetrapods, genus = "genus", family = "family",
                          order = "order", class = "class", resolution = "genus")
 ```
 
@@ -264,7 +264,7 @@ Now, let's use this function to extract the unique genera for each collection (=
 
 ```{r}
 # Use group_apply along with tax_unique:
-coll_genera <- group_apply(occdf = maj_tetrapods,
+coll_genera <- group_apply(data = maj_tetrapods,
                            group = c("collection_no"),
                            fun = tax_unique,
                            genus = "genus",
@@ -352,7 +352,7 @@ We can use this in combination with `group_apply` to calculate the average for e
 space_tetrapods <- subset(maj_tetrapods, !is.na(genus))
 
 # Find temporal range of all genera
-space_tetrapods <- group_apply(occdf = space_tetrapods,
+space_tetrapods <- group_apply(data = space_tetrapods,
                                group = c("bin_midpoint"),
                                fun = tax_range_space,
                                name = "genus",


### PR DESCRIPTION
Part of #167 

TODO: deprecate `occdf` and `taxdf`

## Checklist before requesting a review
- [x] I have read palaeoverse's [standards and structure](https://palaeoverse.palaeoverse.org/articles/structure-and-standards.html)
- [x] I have performed a self-review of my code.
- [ ] I have added function documentation.
- [ ] I have provided sufficient examples of implementation.
- [ ] If it is a core feature, I have added thorough tests.

